### PR TITLE
Update mod-ollama-chat_handler.cpp

### DIFF
--- a/src/mod-ollama-chat_handler.cpp
+++ b/src/mod-ollama-chat_handler.cpp
@@ -281,7 +281,16 @@ void PlayerBotChatHandler::ProcessChat(Player* player, uint32_t /*type*/, uint32
                 // Use the QueryManager to submit the query.
                 std::future<std::string> responseFuture = SubmitQuery(prompt);
                 std::string response = responseFuture.get();
-
+                double avgCharsPerSec = 3.0; // avarage speed of human writting
+                double thinkTime = 1.0; // time in seconds to "think" about answer
+                int responseLength = response.size(); // number of symbols in answer
+                double writingTime = responseLength / avgCharsPerSec; // time for write msg in seconds
+                double totalDelay = writingTime + thinkTime; // overall delay
+                //optional jitter for immersion double jitter = ((rand() % 1000) - 500) / 1000.0; // -0.5s až +0.5s
+                //totalDelay += jitter;//
+                if (totalDelay < 0.5) totalDelay = 0.5; // minimum 0.5s
+                td::this_thread::sleep_for(std::chrono::milliseconds((int)(totalDelay * 1000)));
+              
                 // Reacquire pointers by GUID.
                 Player* botPtr = ObjectAccessor::FindPlayer(ObjectGuid(botGuid));
                 Player* senderPtr = ObjectAccessor::FindPlayer(ObjectGuid(senderGuid));


### PR DESCRIPTION
Before the bot sends the answer back into the game, it waits a delay calculated from the answer length and an average typing speed, plus random jitter (making it feel like a human is reading/thinking and then typing the message).


![image](https://github.com/user-attachments/assets/618192ec-1632-419a-ac21-e1e1b974137a)
after changes at my own copy of your repo it works