### PR TITLE
Dustin/chat history

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@
 - **Random Chatter:**  
   Bots can periodically initiate random, environment-based chat when a real player is nearby. This feature adds an extra layer of immersion to the game world.
 
+- **Chat Memory (Conversation History):**  
+  Bots now have configurable short-term chat memory. Recent conversations between each player and bot are stored and included as context in every LLM prompt, giving responses better context and continuity.
+
+  Bots now recall your recent interactions—responses will reflect the last several lines of chat with each player.
+
 - **Blacklist for Playerbot Commands:**  
   A configurable blacklist prevents bots from responding to chat messages that start with common playerbot command prefixes, ensuring that administrative commands are not inadvertently processed. Additional commands can be appended via the configuration.
 
@@ -121,6 +126,20 @@ All configuration options for mod-ollama-chat are defined in `mod-ollama-chat.co
 - **OllamaChat.EnableRPPersonalities:**  
   Enable distinct roleplay personalities for bots.  
   Default: `0` (false)
+
+- **OllamaChat.ChatHistoryEnabled:**
+  Enable or disable chat history feature.  
+  Default: `1` (true)
+
+- **OllamaChat.MaxConversationHistory:**  
+  The maximum number of recent message pairs (player + bot reply) to track per bot/player combination.  
+  This history is stored in memory and included in the LLM prompt when the same player talks to the bot again.  
+  Default: `5`
+
+- **OllamaChat.ConversationHistorySaveInterval:**  
+  The interval (in minutes) between periodic saves of conversation history from memory to the database.  
+  Set to `0` to disable auto-saving (Bots only store conversations while server is running).  
+  Default: `10`
 
 - **OllamaChat.RandomChatterRealPlayerDistance:**  
   Maximum distance (in game units) a real player must be within to trigger random chatter.  

--- a/conf/mod_ollama_chat.conf.dist
+++ b/conf/mod_ollama_chat.conf.dist
@@ -78,13 +78,22 @@ OllamaChat.MaxRandomInterval = 180
 #     Default:     0 (false)
 OllamaChat.EnableRPPersonalities = 0
 
-# OllamaChat.PersonalityConfPath
-#     Description: The full or relative path to the OllamaChat module's personality configuration file.
-#                  This file contains the definitions for all bot personality prompt templates, one per line.
-#                  Use a path relative to the worldserver binary (e.g., ../etc/modules/mod_ollama_chat.conf).
-#     Example:     OllamaChat.PersonalityConfPath = "../etc/modules/mod_ollama_chat.conf"
-#     Default:     ../etc/modules/mod_ollama_chat.conf
-OllamaChat.PersonalityConfPath = "../etc/modules/mod_ollama_chat.conf"
+# OllamaChat.MaxConversationHistory
+#     Description: The maximum number of recent message pairs (player + bot reply) to track per bot/player combination.
+#                  This history is stored in memory and included in the LLM prompt when the same player talks to the bot again.
+#     Default:     5
+OllamaChat.MaxConversationHistory = 5
+
+# OllamaChat.ConversationHistorySaveInterval
+#     Description: The interval (in minutes) between periodic saves of conversation history from memory to the database.
+#                  Set to 0 to disable auto-saving.
+#     Default:     10
+OllamaChat.ConversationHistorySaveInterval = 10
+
+# OllamaChat.EnableChatHistory
+#     Description: Enables or disables the use of Chat History.
+#     Default:     1 (true)
+OllamaChat.EnableChatHistory = 1
 
 # OllamaChat.RandomChatterRealPlayerDistance
 #     Description: The maximum distance (in game units) a real player must be within for random bot chatter to trigger.
@@ -131,7 +140,7 @@ OllamaChat.DefaultPersonalityPrompt = "Talk like a standard WoW player."
 #       {} 12 - Main subject item or environment observation (e.g., "a murloc", "your sword", "a vendor")
 #
 #     Default: See below.
-OllamaChat.RandomChatterPromptTemplate = "You are a World of Warcraft player in the Wrath of the Lich King expansion. Your name is {}. You are a level {} {}, Race: {}, Gender: {}, Talent Spec: {}, Faction: {}. You are currently located in {}, inside the zone '{}' on map '{}'. Your Personality is '{}'. {} Make it a short statement (under 15 words) using casual WoW-style slang and attitude. Respond as a real WoW player would."
+OllamaChat.RandomChatterPromptTemplate = "You are a World of Warcraft player in the Wrath of the Lich King expansion. Your name is {}. You are a level {} {}, Race: {}, Gender: {}, Talent Spec: {}, Faction: {}. You are currently located in {}, inside the zone '{}' on map '{}'. Your Personality is '{}'. {} Make it a short statement (under 15 words) using casual WoW-style slang and attitude. Respond as a real WoW player would. IMPORTANT: Return only normal conversational replies, do NOT wrap your response in qoutes or double quotes, do not add any extra thoughts or texts or explanations, just the response itself. Do not use any special characters or formatting. Do not use any markdown or code blocks. Do not use any emojis or emoticons. Do not use any hashtags or mentions. Do not use any links or URLs. Do not use any punctuation marks other than periods, commas, and exclamation points. Do not use any abbreviations or acronyms. Do not use any slang or jargon that is not commonly used in World of Warcraft."
 
 # OllamaChat.ChatPromptTemplate
 #   Description: The main template for bot chat prompts sent to the LLM.
@@ -146,7 +155,7 @@ OllamaChat.RandomChatterPromptTemplate = "You are a World of Warcraft player in 
 #     {} 7  - Player's name
 #     {} 8  - Player's message (in-game chat)
 #     {} 9  - Extra info (see OllamaChat.ChatExtraInfoTemplate below)
-OllamaChat.ChatPromptTemplate = "You are a World of Warcraft player in the Wrath of the Lich King expansion version of the game, but you are also knowledgeable about Vanilla WoW and The Burning Crusade. Make sure your responses are relevant to the game lore and context. Your character's name is {} and you are a level {} {}. Your Personality is '{}'. A level {} {} named {} said '{}' in the game chat. Reply (under 15 words) relevant to the message and context. {} Keep your responses natural and unfiltered, just like real WoW players; embrace common slang, faction pride, and rivalry. If someone jokes, joke back. If they’re rude, don’t hold back being rude to them. Show respect to high-level players but be snooty and entitled over lower levels. When giving directions, be precise, using landmarks, flight paths, and major cities for clarity. Keep responses accurate, short and to the point. Be factual about everything like your location, race, class, etc. Do not say you're in a location or are a class or race that you are not. Always prioritize sounding like a real human player."
+OllamaChat.ChatPromptTemplate = "You are a World of Warcraft player in the Wrath of the Lich King expansion version of the game, but you are also knowledgeable about Vanilla WoW and The Burning Crusade. Make sure your responses are relevant to the game lore and context. Your character's name is {} and you are a level {} {}. Your Personality is '{}'. A level {} {} named {} said '{}' in the game chat. Reply (under 15 words) relevant to the message and context. {} Keep your responses natural and unfiltered, just like real WoW players; embrace common slang, faction pride, and rivalry. If someone jokes, joke back. If they’re rude, don’t hold back being rude to them. Show respect to high-level players but be snooty and entitled over lower levels. When giving directions, be precise, using landmarks, flight paths, and major cities for clarity. Keep responses accurate, short and to the point. Be factual about everything like your location, race, class, etc. Do not say you're in a location or are a class or race that you are not. Always prioritize sounding like a real human player. IMPORTANT: Return only normal conversational replies, do NOT wrap your response in qoutes or double quotes, do not add any extra thoughts or texts or explanations, just the response itself. Do not use any special characters or formatting. Do not use any markdown or code blocks. Do not use any emojis or emoticons. Do not use any hashtags or mentions. Do not use any links or URLs. Do not use any punctuation marks other than periods, commas, and exclamation points. Do not use any abbreviations or acronyms. Do not use any slang or jargon that is not commonly used in World of Warcraft."
 
 # OllamaChat.ChatExtraInfoTemplate
 #   Description: The context/details string about the bot and player, injected into the chat prompt as the last parameter.
@@ -171,6 +180,20 @@ OllamaChat.ChatPromptTemplate = "You are a World of Warcraft player in the Wrath
 #     {} 17 - Location info - zone
 #     {} 18 - Location info - map
 OllamaChat.ChatExtraInfoTemplate = "Your info: Race: {}, Gender: {}, Talent Spec: {}, Faction: {}, Guild: {}, Group: {}, Gold: {}. Other players info: Race: {}, Gender: {}, Talent Spec: {}, Faction: {}, Guild: {}, Group: {}, Gold: {}. Approximate distance between you and other player: {:.1f} yards. You are in the area '{}', zone '{}' and map '{}'."
+
+# OllamaChat.ChatHistoryHeaderTemplate
+#   Description: Format for header in conversation history context.
+#   Placeholders use {} in the order below:
+#     {} 1  - Player's name
+OllamaChat.ChatHistoryHeaderTemplate = "Your most recent conversations with {}. Use these as context only but reply to the new message they just sent you.\n"
+
+# OllamaChat.ChatHistoryLineTemplate
+#   Description: Format for each line in conversation history context.
+#   Placeholders use {} in the order below:
+#     {} 1  - Player's name
+#     {} 2  - Player message
+#     {} 3  - Bot reply
+OllamaChat.ChatHistoryLineTemplate = "{} said: '{}'\nYou said: '{}'\n"
 
 # OllamaChat.EnvCommentCreature
 #     Description: A pipe-separated (|) list of template messages for when any creature is spotted nearby.

--- a/conf/mod_ollama_chat.conf.dist
+++ b/conf/mod_ollama_chat.conf.dist
@@ -155,7 +155,7 @@ OllamaChat.RandomChatterPromptTemplate = "You are a World of Warcraft player in 
 #     {} 7  - Player's name
 #     {} 8  - Player's message (in-game chat)
 #     {} 9  - Extra info (see OllamaChat.ChatExtraInfoTemplate below)
-OllamaChat.ChatPromptTemplate = "You are a World of Warcraft player in the Wrath of the Lich King expansion version of the game, but you are also knowledgeable about Vanilla WoW and The Burning Crusade. Make sure your responses are relevant to the game lore and context. Your character's name is {} and you are a level {} {}. Your Personality is '{}'. A level {} {} named {} said '{}' in the game chat. Reply (under 15 words) relevant to the message and context. {} Keep your responses natural and unfiltered, just like real WoW players; embrace common slang, faction pride, and rivalry. If someone jokes, joke back. If they’re rude, don’t hold back being rude to them. Show respect to high-level players but be snooty and entitled over lower levels. When giving directions, be precise, using landmarks, flight paths, and major cities for clarity. Keep responses accurate, short and to the point. Be factual about everything like your location, race, class, etc. Do not say you're in a location or are a class or race that you are not. Always prioritize sounding like a real human player. IMPORTANT: Return only normal conversational replies, do NOT wrap your response in qoutes or double quotes, do not add any extra thoughts or texts or explanations, just the response itself. Do not use any special characters or formatting. Do not use any markdown or code blocks. Do not use any emojis or emoticons. Do not use any hashtags or mentions. Do not use any links or URLs. Do not use any punctuation marks other than periods, commas, and exclamation points. Do not use any abbreviations or acronyms. Do not use any slang or jargon that is not commonly used in World of Warcraft."
+OllamaChat.ChatPromptTemplate = "You are a World of Warcraft player in the Wrath of the Lich King expansion version of the game, but you are also knowledgeable about Vanilla WoW and The Burning Crusade. Make sure your responses are relevant to the game lore and context. Your character's name is {} and you are a level {} {}. Your Personality is '{}'. A level {} {} named {} said '{}' in the game chat. Reply (under 15 words) relevant to the message and context. {} Keep your responses natural and unfiltered, just like real WoW players; embrace common slang, faction pride, and rivalry. If someone jokes, joke back. If they’re rude, don’t hold back being rude to them. Show respect to high-level players but be snooty and entitled over lower levels. When giving directions, be precise, using landmarks, flight paths, and major cities for clarity. Keep responses accurate, short and to the point. Be factual about everything like your location, race, class, etc. Do not say you're in a location or are a class or race that you are not. Always prioritize sounding like a real human player."
 
 # OllamaChat.ChatExtraInfoTemplate
 #   Description: The context/details string about the bot and player, injected into the chat prompt as the last parameter.
@@ -179,7 +179,7 @@ OllamaChat.ChatPromptTemplate = "You are a World of Warcraft player in the Wrath
 #     {} 16 - Location info - area
 #     {} 17 - Location info - zone
 #     {} 18 - Location info - map
-OllamaChat.ChatExtraInfoTemplate = "Your info: Race: {}, Gender: {}, Talent Spec: {}, Faction: {}, Guild: {}, Group: {}, Gold: {}. Other players info: Race: {}, Gender: {}, Talent Spec: {}, Faction: {}, Guild: {}, Group: {}, Gold: {}. Approximate distance between you and other player: {:.1f} yards. You are in the area '{}', zone '{}' and map '{}'."
+OllamaChat.ChatExtraInfoTemplate = "Your info: Race: {}, Gender: {}, Talent Spec: {}, Faction: {}, Guild: {}, Group: {}, Gold: {}. Other players info: Race: {}, Gender: {}, Talent Spec: {}, Faction: {}, Guild: {}, Group: {}, Gold: {}. Approximate distance between you and other player: {:.1f} yards. You are in the area '{}', zone '{}' and map '{}'. INSTRUCTIONS: Reply ONLY to the new message above. Do NOT refer to or reply to any previous conversation unless it relates to the latest message you are replying to. Do NOT add any label, commentary, explanation, or meta-text. Respond as a normal player would, under 15 words, with NO extra formatting or prefix—just the reply."
 
 # OllamaChat.ChatHistoryHeaderTemplate
 #   Description: Format for header in conversation history context.
@@ -193,7 +193,14 @@ OllamaChat.ChatHistoryHeaderTemplate = "Your most recent conversations with {}. 
 #     {} 1  - Player's name
 #     {} 2  - Player message
 #     {} 3  - Bot reply
-OllamaChat.ChatHistoryLineTemplate = "{} said: '{}'\nYou said: '{}'\n"
+OllamaChat.ChatHistoryLineTemplate = "{} said: {}\nYou said: {}\n"
+
+# OllamaChat.ChatHistoryFooterTemplate
+#   Description: Format for footer in conversation history context.
+#   Placeholders use {} in the order below:
+#     {} 1  - Player's name
+#     {} 2  - Player message
+OllamaChat.ChatHistoryHeaderTemplate = "REPLY TO THIS MOST RECENT MESSAGE {}: {}.\n"
 
 # OllamaChat.EnvCommentCreature
 #     Description: A pipe-separated (|) list of template messages for when any creature is spotted nearby.

--- a/data/sql/characters/base/2025_06_14_chat_history.sql
+++ b/data/sql/characters/base/2025_06_14_chat_history.sql
@@ -1,0 +1,11 @@
+
+CREATE TABLE IF NOT EXISTS mod_ollama_chat_history (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    bot_guid BIGINT UNSIGNED NOT NULL,
+    player_guid BIGINT UNSIGNED NOT NULL,
+    timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    player_message TEXT NOT NULL,
+    bot_reply TEXT NOT NULL,
+    -- This unique key prevents any duplicates for the same conversation turn
+    UNIQUE KEY unique_history (bot_guid, player_guid, player_message(255), bot_reply(255))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/mod-ollama-chat_config.cpp
+++ b/src/mod-ollama-chat_config.cpp
@@ -45,6 +45,7 @@ std::string g_ChatExtraInfoTemplate;
 bool g_EnableChatHistory = true;
 std::string g_ChatHistoryHeaderTemplate;
 std::string g_ChatHistoryLineTemplate;
+std::string g_ChatHistoryFooterTemplate;
 
 bool        g_DebugEnabled = false;
 
@@ -167,14 +168,14 @@ std::string GetMultiLineConfigValue(const std::string& configFilePath, const std
 
 void LoadOllamaChatConfig()
 {
-    g_SayDistance       = sConfigMgr->GetOption<float>("OllamaChat.SayDistance", 30.0f);
-    g_YellDistance      = sConfigMgr->GetOption<float>("OllamaChat.YellDistance", 100.0f);
-    g_GeneralDistance   = sConfigMgr->GetOption<float>("OllamaChat.GeneralDistance", 600.0f);
-    g_PlayerReplyChance = sConfigMgr->GetOption<uint32_t>("OllamaChat.PlayerReplyChance", 90);
-    g_BotReplyChance    = sConfigMgr->GetOption<uint32_t>("OllamaChat.BotReplyChance", 10);
-    g_MaxBotsToPick     = sConfigMgr->GetOption<uint32_t>("OllamaChat.MaxBotsToPick", 2);
-    g_OllamaUrl         = sConfigMgr->GetOption<std::string>("OllamaChat.Url", "http://localhost:11434/api/generate");
-    g_OllamaModel       = sConfigMgr->GetOption<std::string>("OllamaChat.Model", "llama3.2:1b");
+    g_SayDistance                     = sConfigMgr->GetOption<float>("OllamaChat.SayDistance", 30.0f);
+    g_YellDistance                    = sConfigMgr->GetOption<float>("OllamaChat.YellDistance", 100.0f);
+    g_GeneralDistance                 = sConfigMgr->GetOption<float>("OllamaChat.GeneralDistance", 600.0f);
+    g_PlayerReplyChance               = sConfigMgr->GetOption<uint32_t>("OllamaChat.PlayerReplyChance", 90);
+    g_BotReplyChance                  = sConfigMgr->GetOption<uint32_t>("OllamaChat.BotReplyChance", 10);
+    g_MaxBotsToPick                   = sConfigMgr->GetOption<uint32_t>("OllamaChat.MaxBotsToPick", 2);
+    g_OllamaUrl                       = sConfigMgr->GetOption<std::string>("OllamaChat.Url", "http://localhost:11434/api/generate");
+    g_OllamaModel                     = sConfigMgr->GetOption<std::string>("OllamaChat.Model", "llama3.2:1b");
 
     g_MaxConcurrentQueries            = sConfigMgr->GetOption<uint32_t>("OllamaChat.MaxConcurrentQueries", 0);
 
@@ -196,7 +197,7 @@ void LoadOllamaChatConfig()
 
     g_ChatPromptTemplate              = sConfigMgr->GetOption<std::string>("OllamaChat.ChatPromptTemplate", "You are a World of Warcraft player in the Wrath of the Lich King expansion version of the game, but you are also knowledgeable about Vanilla WoW and The Burning Crusade. Make sure your responses are relevant to the game lore and context. Your character's name is {} and you are a level {} {}. Your Personality is '{}'. A level {} {} named {} said '{}' in the game chat. Reply (under 15 words) relevant to the message and context. {} Keep your responses natural and unfiltered, just like real WoW players; embrace common slang, faction pride, and rivalry. If someone jokes, joke back. If they’re rude, don’t hold back being rude to them. Show respect to high-level players but be snooty and entitled over lower levels. When giving directions, be precise, using landmarks, flight paths, and major cities for clarity. Keep responses accurate, short and to the point. Be factual about everything like your location, race, class, etc. Do not say you're in a location or are a class or race that you are not. Always prioritize sounding like a real human player. IMPORTANT: Return only normal conversational replies, do NOT wrap your response in qoutes or double quotes, do not add any extra thoughts or texts or explanations, just the response itself. Do not use any special characters or formatting. Do not use any markdown or code blocks. Do not use any emojis or emoticons. Do not use any hashtags or mentions. Do not use any links or URLs. Do not use any punctuation marks other than periods, commas, and exclamation points. Do not use any abbreviations or acronyms. Do not use any slang or jargon that is not commonly used in World of Warcraft.");
     
-    g_ChatExtraInfoTemplate           = sConfigMgr->GetOption<std::string>("OllamaChat.ChatExtraInfoTemplate", "Your info: Race: {}, Gender: {}, Talent Spec: {}, Faction: {}, Guild: {}, Group: {}, Gold: {}. Other players info: Race: {}, Gender: {}, Talent Spec: {}, Faction: {}, Guild: {}, Group: {}, Gold: {}. Approximate distance between you and other player: {:.1f} yards. {}");
+    g_ChatExtraInfoTemplate           = sConfigMgr->GetOption<std::string>("OllamaChat.ChatExtraInfoTemplate", "Your info: Race: {}, Gender: {}, Talent Spec: {}, Faction: {}, Guild: {}, Group: {}, Gold: {}. Other players info: Race: {}, Gender: {}, Talent Spec: {}, Faction: {}, Guild: {}, Group: {}, Gold: {}. Approximate distance between you and other player: {:.1f} yards. You are in the area '{}', zone '{}' and map '{}'. INSTRUCTIONS: Reply ONLY to the new message above. Do NOT refer to or reply to any previous conversation unless it relates to the latest message you are replying to. Do NOT add any label, commentary, explanation, or meta-text. Respond as a normal player would, under 15 words, with NO extra formatting or prefix—just the reply.");
 
     g_DefaultPersonalityPrompt        = sConfigMgr->GetOption<std::string>("OllamaChat.DefaultPersonalityPrompt", "Talk like a standard WoW player.");
 
@@ -204,7 +205,9 @@ void LoadOllamaChatConfig()
     g_ConversationHistorySaveInterval = sConfigMgr->GetOption<uint32_t>("OllamaChat.ConversationHistorySaveInterval", 10);
 
     g_ChatHistoryHeaderTemplate       = sConfigMgr->GetOption<std::string>("OllamaChat.ChatHistoryHeaderTemplate", "Your most recent conversations with {}. Use these as context only but reply to the new message they just sent you.\n");
-    g_ChatHistoryLineTemplate         = sConfigMgr->GetOption<std::string>("OllamaChat.ChatHistoryLineTemplate", "{} said: '{}'\nYou said: '{}'\n");
+    g_ChatHistoryLineTemplate         = sConfigMgr->GetOption<std::string>("OllamaChat.ChatHistoryLineTemplate", "{} said: {}\nYou said: {}\n");
+    g_ChatHistoryFooterTemplate       = sConfigMgr->GetOption<std::string>("OllamaChat.ChatHistoryFooterTemplate", "REPLY TO THIS MOST RECENT MESSAGE {}: {}.\n");
+
 
     g_EnableChatHistory               = sConfigMgr->GetOption<bool>("OllamaChat.EnableChatHistory", true);
 

--- a/src/mod-ollama-chat_config.cpp
+++ b/src/mod-ollama-chat_config.cpp
@@ -30,6 +30,9 @@ uint32_t   g_RandomChatterBotCommentChance   = 25;
 
 bool       g_EnableRPPersonalities           = false;
 
+uint32_t g_MaxConversationHistory = 5;
+uint32_t g_ConversationHistorySaveInterval = 10;
+
 std::string g_RandomChatterPromptTemplate;
 
 std::unordered_map<uint64_t, std::string> g_BotPersonalityList;
@@ -39,9 +42,18 @@ std::vector<std::string> g_PersonalityKeys;
 std::string g_ChatPromptTemplate;
 std::string g_ChatExtraInfoTemplate;
 
+bool g_EnableChatHistory = true;
+std::string g_ChatHistoryHeaderTemplate;
+std::string g_ChatHistoryLineTemplate;
+
 bool        g_DebugEnabled = false;
 
 std::string g_DefaultPersonalityPrompt;
+
+// Conversation history store
+std::unordered_map<uint64_t, std::unordered_map<uint64_t, std::deque<std::pair<std::string, std::string>>>> g_BotConversationHistory;
+std::mutex g_ConversationHistoryMutex;
+time_t g_LastHistorySaveTime = 0;
 
 // Default blacklist commands; these are prefixes that indicate the message is a command.
 std::vector<std::string> g_BlacklistCommands = {
@@ -180,15 +192,23 @@ void LoadOllamaChatConfig()
 
     g_EnableRPPersonalities           = sConfigMgr->GetOption<bool>("OllamaChat.EnableRPPersonalities", false);
 
-    g_RandomChatterPromptTemplate     = sConfigMgr->GetOption<std::string>("OllamaChat.RandomChatterPromptTemplate", "You are a World of Warcraft player in the Wrath of the Lich King expansion. Your name is {}. You are a level {} {}, Race: {}, Gender: {}, Talent Spec: {}, Faction: {}. You are currently located in {}, inside the zone '{}' on map '{}'. Your Personality is '{}'. {} Make it a short statement (under 15 words) using casual WoW-style slang and attitude. Respond as a real WoW player would.");
+    g_RandomChatterPromptTemplate     = sConfigMgr->GetOption<std::string>("OllamaChat.RandomChatterPromptTemplate", "You are a World of Warcraft player in the Wrath of the Lich King expansion. Your name is {}. You are a level {} {}, Race: {}, Gender: {}, Talent Spec: {}, Faction: {}. You are currently located in {}, inside the zone '{}' on map '{}'. Your Personality is '{}'. {} Make it a short statement (under 15 words) using casual WoW-style slang and attitude. Respond as a real WoW player would. IMPORTANT: Return only normal conversational replies, do NOT wrap your response in qoutes or double quotes, do not add any extra thoughts or texts or explanations, just the response itself. Do not use any special characters or formatting. Do not use any markdown or code blocks. Do not use any emojis or emoticons. Do not use any hashtags or mentions. Do not use any links or URLs. Do not use any punctuation marks other than periods, commas, and exclamation points. Do not use any abbreviations or acronyms. Do not use any slang or jargon that is not commonly used in World of Warcraft.");
 
-    g_ChatPromptTemplate              = sConfigMgr->GetOption<std::string>("OllamaChat.ChatPromptTemplate", "You are a World of Warcraft player in the Wrath of the Lich King expansion version of the game, but you are also knowledgeable about Vanilla WoW and The Burning Crusade. Make sure your responses are relevant to the game lore and context. Your character's name is {} and you are a level {} {}. Your Personality is '{}'. A level {} {} named {} said '{}' in the game chat. Reply (under 15 words) relevant to the message and context. {} Keep your responses natural and unfiltered, just like real WoW players; embrace common slang, faction pride, and rivalry. If someone jokes, joke back. If they’re rude, don’t hold back being rude to them. Show respect to high-level players but be snooty and entitled over lower levels. When giving directions, be precise, using landmarks, flight paths, and major cities for clarity. Keep responses accurate, short and to the point. Be factual about everything like your location, race, class, etc. Do not say you're in a location or are a class or race that you are not. Always prioritize sounding like a real human player.");
+    g_ChatPromptTemplate              = sConfigMgr->GetOption<std::string>("OllamaChat.ChatPromptTemplate", "You are a World of Warcraft player in the Wrath of the Lich King expansion version of the game, but you are also knowledgeable about Vanilla WoW and The Burning Crusade. Make sure your responses are relevant to the game lore and context. Your character's name is {} and you are a level {} {}. Your Personality is '{}'. A level {} {} named {} said '{}' in the game chat. Reply (under 15 words) relevant to the message and context. {} Keep your responses natural and unfiltered, just like real WoW players; embrace common slang, faction pride, and rivalry. If someone jokes, joke back. If they’re rude, don’t hold back being rude to them. Show respect to high-level players but be snooty and entitled over lower levels. When giving directions, be precise, using landmarks, flight paths, and major cities for clarity. Keep responses accurate, short and to the point. Be factual about everything like your location, race, class, etc. Do not say you're in a location or are a class or race that you are not. Always prioritize sounding like a real human player. IMPORTANT: Return only normal conversational replies, do NOT wrap your response in qoutes or double quotes, do not add any extra thoughts or texts or explanations, just the response itself. Do not use any special characters or formatting. Do not use any markdown or code blocks. Do not use any emojis or emoticons. Do not use any hashtags or mentions. Do not use any links or URLs. Do not use any punctuation marks other than periods, commas, and exclamation points. Do not use any abbreviations or acronyms. Do not use any slang or jargon that is not commonly used in World of Warcraft.");
     
     g_ChatExtraInfoTemplate           = sConfigMgr->GetOption<std::string>("OllamaChat.ChatExtraInfoTemplate", "Your info: Race: {}, Gender: {}, Talent Spec: {}, Faction: {}, Guild: {}, Group: {}, Gold: {}. Other players info: Race: {}, Gender: {}, Talent Spec: {}, Faction: {}, Guild: {}, Group: {}, Gold: {}. Approximate distance between you and other player: {:.1f} yards. {}");
 
     g_DefaultPersonalityPrompt        = sConfigMgr->GetOption<std::string>("OllamaChat.DefaultPersonalityPrompt", "Talk like a standard WoW player.");
 
-    
+    g_MaxConversationHistory          = sConfigMgr->GetOption<uint32_t>("OllamaChat.MaxConversationHistory", 5);
+    g_ConversationHistorySaveInterval = sConfigMgr->GetOption<uint32_t>("OllamaChat.ConversationHistorySaveInterval", 10);
+
+    g_ChatHistoryHeaderTemplate       = sConfigMgr->GetOption<std::string>("OllamaChat.ChatHistoryHeaderTemplate", "Your most recent conversations with {}. Use these as context only but reply to the new message they just sent you.\n");
+    g_ChatHistoryLineTemplate         = sConfigMgr->GetOption<std::string>("OllamaChat.ChatHistoryLineTemplate", "{} said: '{}'\nYou said: '{}'\n");
+
+    g_EnableChatHistory               = sConfigMgr->GetOption<bool>("OllamaChat.EnableChatHistory", true);
+
+
     // Load extra blacklist commands from config (comma-separated list)
     std::string extraBlacklist = sConfigMgr->GetOption<std::string>("OllamaChat.BlacklistCommands", "");
     if (!extraBlacklist.empty())
@@ -277,6 +297,34 @@ void LoadPersonalityTemplatesFromDB()
     } while (result->NextRow());
 }
 
+void LoadBotConversationHistoryFromDB()
+{
+    QueryResult result = CharacterDatabase.Query(
+        "SELECT bot_guid, player_guid, player_message, bot_reply FROM mod_ollama_chat_history ORDER BY timestamp ASC"
+    );
+    if (!result)
+        return;
+
+    std::lock_guard<std::mutex> lock(g_ConversationHistoryMutex);
+    g_BotConversationHistory.clear();
+
+    do {
+        uint64_t botGuid = (*result)[0].Get<uint64_t>();
+        uint64_t playerGuid = (*result)[1].Get<uint64_t>();
+        std::string playerMsg = (*result)[2].Get<std::string>();
+        std::string botReply = (*result)[3].Get<std::string>();
+
+        auto& playerHistory = g_BotConversationHistory[botGuid][playerGuid];
+        playerHistory.push_back({ playerMsg, botReply });
+        while (playerHistory.size() > g_MaxConversationHistory)
+        {
+            playerHistory.pop_front();
+        }
+
+    } while (result->NextRow());
+
+}
+
 
 // Definition of the configuration WorldScript.
 OllamaChatConfigWorldScript::OllamaChatConfigWorldScript() : WorldScript("OllamaChatConfigWorldScript") { }
@@ -286,4 +334,6 @@ void OllamaChatConfigWorldScript::OnStartup()
     curl_global_init(CURL_GLOBAL_ALL);
     LoadOllamaChatConfig();
     LoadBotPersonalityList();
+    LoadBotConversationHistoryFromDB();
+
 }

--- a/src/mod-ollama-chat_config.h
+++ b/src/mod-ollama-chat_config.h
@@ -35,6 +35,7 @@ extern time_t     g_LastHistorySaveTime;
 
 extern std::string g_ChatHistoryHeaderTemplate;
 extern std::string g_ChatHistoryLineTemplate;
+extern std::string g_ChatHistoryFooterTemplate;
 extern bool g_EnableChatHistory;
 
 extern std::string g_RandomChatterPromptTemplate;

--- a/src/mod-ollama-chat_config.h
+++ b/src/mod-ollama-chat_config.h
@@ -27,7 +27,15 @@ extern uint32_t   g_RandomChatterBotCommentChance;
 
 extern bool       g_EnableRPPersonalities;
 
-extern std::string g_PersonalityConfPath;
+extern std::unordered_map<uint64_t, std::unordered_map<uint64_t, std::deque<std::pair<std::string, std::string>>>> g_BotConversationHistory;
+extern std::mutex g_ConversationHistoryMutex;
+extern uint32_t   g_MaxConversationHistory;
+extern uint32_t   g_ConversationHistorySaveInterval;
+extern time_t     g_LastHistorySaveTime;
+
+extern std::string g_ChatHistoryHeaderTemplate;
+extern std::string g_ChatHistoryLineTemplate;
+extern bool g_EnableChatHistory;
 
 extern std::string g_RandomChatterPromptTemplate;
 

--- a/src/mod-ollama-chat_handler.cpp
+++ b/src/mod-ollama-chat_handler.cpp
@@ -184,7 +184,7 @@ void SaveBotConversationHistoryToDB()
 }
 
 
-std::string GetBotHistoryPrompt(uint64_t botGuid, uint64_t playerGuid)
+std::string GetBotHistoryPrompt(uint64_t botGuid, uint64_t playerGuid, std::string playerMessage)
 {
     if(!g_EnableChatHistory)
     {
@@ -204,9 +204,13 @@ std::string GetBotHistoryPrompt(uint64_t botGuid, uint64_t playerGuid)
     Player* player = ObjectAccessor::FindPlayer(ObjectGuid(playerGuid));
     std::string playerName = player ? player->GetName() : "The player";
 
+    result += fmt::format(g_ChatHistoryHeaderTemplate, playerName);
+
     for (const auto& entry : playerIt->second) {
         result += fmt::format(g_ChatHistoryLineTemplate, playerName, entry.first, entry.second);
     }
+
+    result += fmt::format(g_ChatHistoryFooterTemplate, playerName, playerMessage);
 
     return result;
 }
@@ -567,8 +571,6 @@ static bool IsBotEligibleForChatChannelLocal(Player* bot, Player* player,
         uint64_t botGuid                = bot->GetGUID().GetRawValue();
         uint64_t playerGuid             = player->GetGUID().GetRawValue();
 
-        std::string chatHistory         = GetBotHistoryPrompt(botGuid, playerGuid);
-
         std::string personality         = GetBotPersonality(bot);
         std::string personalityPrompt   = GetPersonalityPromptAddition(personality);
         std::string botName             = bot->GetName();
@@ -598,6 +600,8 @@ static bool IsBotEligibleForChatChannelLocal(Player* bot, Player* player,
         std::string playerGroupStatus   = (player->GetGroup() ? "In a group" : "Solo");
         uint32_t playerGold             = player->GetMoney() / 10000;
         float playerDistance            = player->IsInWorld() && bot->IsInWorld() ? player->GetDistance(bot) : -1.0f;
+
+        std::string chatHistory         = GetBotHistoryPrompt(botGuid, playerGuid, playerMessage);
 
         std::string extraInfo = fmt::format(
             g_ChatExtraInfoTemplate,

--- a/src/mod-ollama-chat_handler.h
+++ b/src/mod-ollama-chat_handler.h
@@ -20,6 +20,8 @@ extern const char* ChatChannelSourceLocalStr[];
 std::string rtrim(const std::string& s);
 ChatChannelSourceLocal GetChannelSourceLocal(uint32_t type);
 
+void SaveBotConversationHistoryToDB();
+
 class PlayerBotChatHandler : public PlayerScript
 {
 public:

--- a/src/mod-ollama-chat_random.cpp
+++ b/src/mod-ollama-chat_random.cpp
@@ -1,5 +1,6 @@
 #include "mod-ollama-chat_random.h"
 #include "mod-ollama-chat_config.h"
+#include "mod-ollama-chat_handler.h"
 #include "Log.h"
 #include "Player.h"
 #include "PlayerbotAI.h"
@@ -33,6 +34,16 @@ void OllamaBotRandomChatter::OnUpdate(uint32 diff)
 {
     if (!g_Enable || !g_EnableRandomChatter)
         return;
+
+    if (g_ConversationHistorySaveInterval > 0)
+    {
+        time_t now = time(nullptr);
+        if (difftime(now, g_LastHistorySaveTime) >= g_ConversationHistorySaveInterval * 60)
+        {
+            SaveBotConversationHistoryToDB();
+            g_LastHistorySaveTime = now;
+        }
+    }
 
     static uint32_t timer = 0;
     if (timer <= diff)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1ee68f43-90ae-4fcd-9ba3-6aed6b22811e)

## Feature: Per-Player/Bot Chat History Context

### Summary

This PR implements a **per-player/bot chat history** feature for `mod-ollama-chat`. Bots now track and store recent conversations with each player and use this history as context for LLM responses.

---

### Key Details

- **Conversation Memory**
  - Each bot/player pair keeps up to `OllamaChat.MaxConversationHistory` recent (player message + bot reply) pairs.
  - History is stored in memory and persisted in the `mod_ollama_chat_history` table.
  - History is automatically reloaded from the database on server restart.

- **LLM Prompt Context**
  - When a bot generates a response, recent chat history with the player is included in the LLM prompt to improve conversational continuity and context awareness.

- **Configuration**
  - Controlled by a config option:
    ```ini
    # Maximum recent message pairs per bot/player to use as context.
    # Set to 0 to disable history.
    OllamaChat.MaxConversationHistory = 5
    ```
  - Increase for more context (higher resource use); set to `0` to disable history context entirely.

- **Automatic Cleanup**
  - Oldest entries are pruned as new ones arrive, keeping only the most recent N pairs.

---

### Impact

- Bots are now **context-aware** and maintain conversation memory per player.
- Reduces repetitive, off-topic, or out-of-context responses.
- Server owners can adjust history depth for performance and conversational quality.
