### PR TITLE
Adding support for limiting the number of random bots that are chosen…

### DIFF
--- a/conf/mod_ollama_chat.conf.dist
+++ b/conf/mod_ollama_chat.conf.dist
@@ -105,6 +105,13 @@ OllamaChat.RandomChatterRealPlayerDistance = 40.0
 #     Default:     25
 OllamaChat.RandomChatterBotCommentChance = 25
 
+# OllamaChat.RandomChatterMaxBotsPerPlayer
+#     Description: The maximum number of AI bots that can trigger per random chatter update when a real player is nearby.
+#                  This limits how many bots can respond at once to avoid spam.
+#                   Each bot can only process once per tick, no duplicates if multiple real players are close.
+#     Default:     2
+OllamaChat.RandomChatterMaxBotsPerPlayer = 2
+
 # OllamaChat.BlacklistCommands
 #     Description: A comma-separated list of command prefixes that should be ignored by AI bots.
 #                  If a message starts with any of these prefixes, the bot will not respond.
@@ -241,10 +248,10 @@ OllamaChat.EnvCommentBagItemSell = You are trying persuasively to sell {} of thi
 
 # OllamaChat.EnvCommentSpell
 #     Description: A pipe-separated (|) list of template messages about a random known spell.
-#                  Use '{}' as a placeholder for the spell name.
-#     Example:     Talk about use cases or strategies for your spell '{}'.|Your spell '{}' comes in handy sometimes.
-#     Default:     Talk about use cases or strategies for your spell '{}'.
-OllamaChat.EnvCommentSpell = Talk about use cases or strategies for your spell '{}'.
+#                  Use '{}' as placeholders for: spell name, effect, and cost, in that order.
+#     Example:     Discuss possible uses or strategies for '{}', which {} and costs {}.|Explain situations where '{}' is useful ({}; costs {}).
+#     Default:     Discuss possible uses or strategies for '{}', which {} and costs {}.
+OllamaChat.EnvCommentSpell = Discuss possible uses or strategies for '{}', which {} and costs {}.
 
 # OllamaChat.EnvCommentQuestArea
 #     Description: A pipe-separated (|) list of template messages to suggest an area to quest in.

--- a/src/mod-ollama-chat_config.cpp
+++ b/src/mod-ollama-chat_config.cpp
@@ -27,6 +27,8 @@ uint32_t   g_MinRandomInterval               = 45;
 uint32_t   g_MaxRandomInterval               = 180;
 float      g_RandomChatterRealPlayerDistance = 40.0f;
 uint32_t   g_RandomChatterBotCommentChance   = 25;
+uint32_t   g_RandomChatterMaxBotsPerPlayer   = 2;
+
 
 bool       g_EnableRPPersonalities           = false;
 
@@ -188,7 +190,8 @@ void LoadOllamaChatConfig()
     g_MaxRandomInterval               = sConfigMgr->GetOption<uint32_t>("OllamaChat.MaxRandomInterval", 180);
     g_RandomChatterRealPlayerDistance = sConfigMgr->GetOption<float>("OllamaChat.RandomChatterRealPlayerDistance", 40.0f);
     g_RandomChatterBotCommentChance   = sConfigMgr->GetOption<uint32_t>("OllamaChat.RandomChatterBotCommentChance", 25);
-    
+    g_RandomChatterMaxBotsPerPlayer   = sConfigMgr->GetOption<uint32_t>("OllamaChat.RandomChatterMaxBotsPerPlayer", 2);
+
     g_MaxConcurrentQueries            = sConfigMgr->GetOption<uint32_t>("OllamaChat.MaxConcurrentQueries", 0);
 
     g_EnableRPPersonalities           = sConfigMgr->GetOption<bool>("OllamaChat.EnableRPPersonalities", false);
@@ -258,7 +261,7 @@ void LoadOllamaChatConfig()
     g_EnvCommentEquippedItem    = LoadEnvCommentVector("OllamaChat.EnvCommentEquippedItem", { "Talk about your equipped item {}." });
     g_EnvCommentBagItem         = LoadEnvCommentVector("OllamaChat.EnvCommentBagItem", { "You notice a {} in your bag." });
     g_EnvCommentBagItemSell     = LoadEnvCommentVector("OllamaChat.EnvCommentBagItemSell", { "You are trying persuasively to sell {} of this item {}." });
-    g_EnvCommentSpell           = LoadEnvCommentVector("OllamaChat.EnvCommentSpell", { "Talk about use cases or strategies for your spell '{}'." });
+    g_EnvCommentSpell           = LoadEnvCommentVector("OllamaChat.EnvCommentSpell", { "Discuss possible uses or strategies for '{}', which {} and costs {}.." });
     g_EnvCommentQuestArea       = LoadEnvCommentVector("OllamaChat.EnvCommentQuestArea", { "Suggest you could go questing around {}." });
     g_EnvCommentVendor          = LoadEnvCommentVector("OllamaChat.EnvCommentVendor", { "You spot {} selling wares nearby." });
     g_EnvCommentQuestgiver      = LoadEnvCommentVector("OllamaChat.EnvCommentQuestgiver", { "{} looks like they have {} quests for anyone brave enough." });

--- a/src/mod-ollama-chat_config.h
+++ b/src/mod-ollama-chat_config.h
@@ -24,6 +24,7 @@ extern uint32_t   g_MinRandomInterval;
 extern uint32_t   g_MaxRandomInterval;
 extern float      g_RandomChatterRealPlayerDistance;
 extern uint32_t   g_RandomChatterBotCommentChance;
+extern uint32_t   g_RandomChatterMaxBotsPerPlayer;
 
 extern bool       g_EnableRPPersonalities;
 


### PR DESCRIPTION
## PR: Limit Bot Random Chatter Per Player & Improve Spell Chat Comments

### Features Added

- **Configurable Bot Chatter Limit**
  - Added new config: `OllamaChat.RandomChatterMaxBotsPerPlayer`
  - Limits the number of bots per real player that may process random chatter each tick (default: 2).
  - Reduces potential spam and allows better control over bot frequency.

- **Improved Spell Selection for Bot Chatter**
  - Random spell comments now only select spells that are:
    - Usable (not passive, not generic, not on cooldown)
  - Ensures bots only talk about relevant, active spells.

- **Enhanced Spell Comment Template Support**
  - Spell comment templates now support three placeholders:
    - `{}` = spell name
    - `{}` = spell effect
    - `{}` = spell cost
  - Example template:
    - `Discuss possible uses or strategies for '{}', which {} and costs {}.`

### Configuration Changes

- **OllamaChat.RandomChatter.MaxBotsPerPlayer**
  - *Type*: Integer
  - *Default*: 2
  - *Description*: Maximum number of bots per real player allowed to process random chatter per tick.

- **OllamaChat.EnvCommentSpell**
  - *Placeholders*: `{}` for spell name, `{}` for effect, `{}` for cost
  - *Example*:
    - `OllamaChat.EnvCommentSpell = Discuss possible uses or strategies for '{}', which {} and costs {}.`
  - *Multiple templates can be separated with `|`.*

### Code/Logic Changes

- Refactored `HandleRandomChatter()`:
  - Loops over all real players
  - Collects all bots in range of each player
  - Shuffles and processes up to `MaxBotsPerPlayer` bots per player per tick
  - Ensures bots do not comment more than once per tick even if near multiple players

- Updated spell selection logic for bot comments:
  - Considers only spells that are active, not passive, not generic, and off cooldown
  - Passes spell name, effect, and cost to the template

### Documentation

- Updated config documentation for new and modified variables, including example templates using all three placeholders.

---

**This PR improves random bot chatter realism, prevents excessive spam, and makes spell-related comments much more informative and context-aware.**
