### PR TITLE
Adding more Ollama API support settings to the Conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,38 @@ All configuration options for mod-ollama-chat are defined in `mod-ollama-chat.co
   The model identifier for the Ollama API query.  
   Default: `llama3.2:1b`
 
+- **OllamaChat.Temperature:**  
+  Controls model creativity and randomness. Lower values (e.g., 0.2) make replies more focused and predictable; higher values (e.g., 1.0) make replies more creative and varied.  
+  Default: `0.8`
+
+- **OllamaChat.TopP:**  
+  Nucleus sampling parameter for randomness. Lower values restrict the model’s choices, higher values make responses more open and diverse.  
+  Default: `0.95`
+
+- **OllamaChat.RepeatPenalty:**  
+  Discourages the model from repeating phrases. 1.0 = off, higher values reduce repeated output.  
+  Default: `1.1`
+
+- **OllamaChat.NumCtx:**  
+  Sets the maximum context window (in tokens) for each generation. 0 uses the model’s default context size.  
+  Default: `0`
+
+- **OllamaChat.NumPredict:**  
+  Maximum number of tokens the model will generate in a reply. 0 disables the limit (unlimited).  
+  Default: `0`
+
+- **OllamaChat.Stop:**  
+  Comma-separated list of stop sequences. If the model generates any of these strings, output ends immediately.  
+  Example: `User:,Bot:` (leave empty to disable)
+
+- **OllamaChat.SystemPrompt:**  
+  Optional. System prompt to globally influence bot style, persona, or behavior for all replies.  
+  Default: *(empty)*
+
+- **OllamaChat.Seed:**  
+  Optional. Set a numeric value to make model replies deterministic and repeatable.  
+  Default: *(empty)*
+
 - **OllamaChat.EnableRandomChatter:**  
   Enable or disable random chatter from bots.  
   Default: `1` (true)

--- a/conf/mod_ollama_chat.conf.dist
+++ b/conf/mod_ollama_chat.conf.dist
@@ -49,6 +49,66 @@ OllamaChat.Url = http://localhost:11434/api/generate
 #     Default:     llama3.2:1b
 OllamaChat.Model = llama3.2:1b
 
+# OllamaChat.NumPredict
+#     Description: Maximum number of tokens to generate in Ollama responses.
+#     0 = unlimited (default). Only set if you want a hard cap.
+#     Default: 0
+OllamaChat.NumPredict = 0
+
+# OllamaChat.Temperature
+#     Description: Controls the "creativity" or randomness of the model’s output.
+#                  Lower values (e.g., 0.2) = more focused, repetitive, and predictable.
+#                  Higher values (e.g., 1.0) = more random, creative, or surprising.
+#                  0.8 is the Ollama default.
+#     Example:     OllamaChat.Temperature = 0.6
+#     Default:     0.8
+OllamaChat.Temperature = 0.8
+
+# OllamaChat.TopP
+#     Description: Controls nucleus sampling, another way to shape randomness.
+#                  Lower values (e.g., 0.5) = more conservative.
+#                  Higher values (up to 1.0) = more open.
+#                  0.95 is the Ollama default.
+#     Example:     OllamaChat.TopP = 0.9
+#     Default:     0.95
+OllamaChat.TopP = 0.95
+
+# OllamaChat.RepeatPenalty
+#     Description: Discourages repetition in model output.
+#                  1.0 = no penalty. Higher (e.g., 1.2) = less repetition.
+#                  1.1 is the Ollama default.
+#     Example:     OllamaChat.RepeatPenalty = 1.2
+#     Default:     1.1
+OllamaChat.RepeatPenalty = 1.1
+
+# OllamaChat.NumCtx
+#     Description: Maximum context length (in tokens) sent to the model.
+#                  0 = model default. Use a value only if you want to restrict or expand context.
+#                  Example for Llama-3 8B: 8192. For 70B: 8192/32768.
+#     Example:     OllamaChat.NumCtx = 4096
+#     Default:     0
+OllamaChat.NumCtx = 0
+
+# OllamaChat.Stop
+#     Description: Optional. Comma-separated list of string "stop sequences". If the model outputs any of these strings, it will immediately stop generating further text and return the response up to that point. Use this to prevent the model from continuing into unwanted sections, such as another user's dialogue turn in a chat application.
+#                  Example: "User:,Bot:" will stop the output if "User:" or "Bot:" appears in the response. Leave blank to disable.
+#     Example:     OllamaChat.Stop = User:,Bot:
+#     Default:     (empty)
+OllamaChat.Stop =
+
+# OllamaChat.SystemPrompt
+#     Description: Optional. Content for the "system" field sent to Ollama. Can be used to steer or "prime" the model's behavior globally.
+#                  Leave blank for no system prompt, or enter your own.
+#     Example:     OllamaChat.SystemPrompt = "Always answer as if you are a WoW quest giver."
+#     Default:     (empty)
+OllamaChat.SystemPrompt =
+
+# OllamaChat.Seed
+#     Description: Optional. Random seed for deterministic generation. Set to a number for repeatable results, or leave blank for normal random output.
+#     Example:     OllamaChat.Seed = 42
+#     Default:     (empty)
+OllamaChat.Seed =
+
 # OllamaChat.EnableRandomChatter
 #     Description: Enable or disable random chatter from AI bots when a real player is nearby.
 #     Default:     1 (true)

--- a/src/mod-ollama-chat_config.cpp
+++ b/src/mod-ollama-chat_config.cpp
@@ -17,18 +17,25 @@ uint32_t   g_BotReplyChance    = 10;
 uint32_t   g_MaxBotsToPick     = 2;
 std::string g_OllamaUrl        = "http://localhost:11434/api/generate";
 std::string g_OllamaModel      = "llama3.2:1b";
+uint32_t g_OllamaNumPredict    = 0;
 
 // New configuration option: API max concurrent queries (0 means no limit)
-uint32_t   g_MaxConcurrentQueries = 0;
+uint32_t    g_MaxConcurrentQueries = 0;
 
-bool       g_Enable                          = true;
-bool       g_EnableRandomChatter             = true;
-uint32_t   g_MinRandomInterval               = 45;
-uint32_t   g_MaxRandomInterval               = 180;
-float      g_RandomChatterRealPlayerDistance = 40.0f;
-uint32_t   g_RandomChatterBotCommentChance   = 25;
-uint32_t   g_RandomChatterMaxBotsPerPlayer   = 2;
-
+bool        g_Enable                          = true;
+bool        g_EnableRandomChatter             = true;
+uint32_t    g_MinRandomInterval               = 45;
+uint32_t    g_MaxRandomInterval               = 180;
+float       g_RandomChatterRealPlayerDistance = 40.0f;
+uint32_t    g_RandomChatterBotCommentChance   = 25;
+uint32_t    g_RandomChatterMaxBotsPerPlayer   = 2;
+float       g_OllamaTemperature = 0.8f;
+float       g_OllamaTopP = 0.95f;
+float       g_OllamaRepeatPenalty = 1.1f;
+uint32_t    g_OllamaNumCtx = 0;
+std::string g_OllamaStop = "";
+std::string g_OllamaSystemPrompt = "";
+std::string g_OllamaSeed = "";
 
 bool       g_EnableRPPersonalities           = false;
 
@@ -178,6 +185,15 @@ void LoadOllamaChatConfig()
     g_MaxBotsToPick                   = sConfigMgr->GetOption<uint32_t>("OllamaChat.MaxBotsToPick", 2);
     g_OllamaUrl                       = sConfigMgr->GetOption<std::string>("OllamaChat.Url", "http://localhost:11434/api/generate");
     g_OllamaModel                     = sConfigMgr->GetOption<std::string>("OllamaChat.Model", "llama3.2:1b");
+    g_OllamaNumPredict                = sConfigMgr->GetOption<uint32_t>("OllamaChat.NumPredict", 0);
+    g_OllamaTemperature               = sConfigMgr->GetOption<float>("OllamaChat.Temperature", 0.8f);
+    g_OllamaTopP                      = sConfigMgr->GetOption<float>("OllamaChat.TopP", 0.95f);
+    g_OllamaRepeatPenalty             = sConfigMgr->GetOption<float>("OllamaChat.RepeatPenalty", 1.1f);
+    g_OllamaNumCtx                    = sConfigMgr->GetOption<uint32_t>("OllamaChat.NumCtx", 0);
+    g_OllamaNumPredict                = sConfigMgr->GetOption<uint32_t>("OllamaChat.NumPredict", 0);
+    g_OllamaStop                      = sConfigMgr->GetOption<std::string>("OllamaChat.Stop", "");
+    g_OllamaSystemPrompt              = sConfigMgr->GetOption<std::string>("OllamaChat.SystemPrompt", "");
+    g_OllamaSeed                      = sConfigMgr->GetOption<std::string>("OllamaChat.Seed", "");
 
     g_MaxConcurrentQueries            = sConfigMgr->GetOption<uint32_t>("OllamaChat.MaxConcurrentQueries", 0);
 

--- a/src/mod-ollama-chat_config.h
+++ b/src/mod-ollama-chat_config.h
@@ -6,51 +6,59 @@
 #include <vector>
 #include "ScriptMgr.h"  // Ensure WorldScript is defined
 
-extern float      g_SayDistance;
-extern float      g_YellDistance;
-extern float      g_GeneralDistance;
-extern uint32_t   g_PlayerReplyChance;
-extern uint32_t   g_BotReplyChance;
-extern uint32_t   g_MaxBotsToPick;
-extern std::string g_OllamaUrl;
-extern std::string g_OllamaModel;
+extern float            g_SayDistance;
+extern float            g_YellDistance;
+extern float            g_GeneralDistance;
+extern uint32_t         g_PlayerReplyChance;
+extern uint32_t         g_BotReplyChance;
+extern uint32_t         g_MaxBotsToPick;
+extern std::string      g_OllamaUrl;
+extern std::string      g_OllamaModel;
+extern uint32_t         g_OllamaNumPredict;
+extern float            g_OllamaTemperature;
+extern float            g_OllamaTopP;
+extern float            g_OllamaRepeatPenalty;
+extern uint32_t         g_OllamaNumCtx;
+extern std::string      g_OllamaStop;
+extern std::string      g_OllamaSystemPrompt;
+extern std::string      g_OllamaSeed;
 
-extern uint32_t   g_MaxConcurrentQueries;
+extern uint32_t         g_MaxConcurrentQueries;
 
-extern bool       g_Enable;
-extern bool       g_EnableRandomChatter;
-extern bool       g_DebugEnabled;
-extern uint32_t   g_MinRandomInterval;
-extern uint32_t   g_MaxRandomInterval;
-extern float      g_RandomChatterRealPlayerDistance;
-extern uint32_t   g_RandomChatterBotCommentChance;
-extern uint32_t   g_RandomChatterMaxBotsPerPlayer;
+extern bool             g_Enable;
+extern bool             g_EnableRandomChatter;
+extern bool             g_DebugEnabled;
+extern uint32_t         g_MinRandomInterval;
+extern uint32_t         g_MaxRandomInterval;
+extern float            g_RandomChatterRealPlayerDistance;
+extern uint32_t         g_RandomChatterBotCommentChance;
+extern uint32_t         g_RandomChatterMaxBotsPerPlayer;
 
-extern bool       g_EnableRPPersonalities;
+extern bool             g_EnableRPPersonalities;
 
 extern std::unordered_map<uint64_t, std::unordered_map<uint64_t, std::deque<std::pair<std::string, std::string>>>> g_BotConversationHistory;
-extern std::mutex g_ConversationHistoryMutex;
-extern uint32_t   g_MaxConversationHistory;
-extern uint32_t   g_ConversationHistorySaveInterval;
-extern time_t     g_LastHistorySaveTime;
+extern std::mutex       g_ConversationHistoryMutex;
+extern uint32_t         g_MaxConversationHistory;
+extern uint32_t         g_ConversationHistorySaveInterval;
+extern time_t           g_LastHistorySaveTime;
 
-extern std::string g_ChatHistoryHeaderTemplate;
-extern std::string g_ChatHistoryLineTemplate;
-extern std::string g_ChatHistoryFooterTemplate;
-extern bool g_EnableChatHistory;
+extern std::string      g_ChatHistoryHeaderTemplate;
+extern std::string      g_ChatHistoryLineTemplate;
+extern std::string      g_ChatHistoryFooterTemplate;
+extern bool             g_EnableChatHistory;
 
-extern std::string g_RandomChatterPromptTemplate;
+extern std::string      g_RandomChatterPromptTemplate;
 
 extern std::unordered_map<uint64_t, std::string> g_BotPersonalityList;
 extern std::unordered_map<std::string, std::string> g_PersonalityPrompts;
 extern std::vector<std::string> g_PersonalityKeys;
 
-extern std::string g_ChatPromptTemplate;
-extern std::string g_ChatExtraInfoTemplate;
+extern std::string      g_ChatPromptTemplate;
+extern std::string      g_ChatExtraInfoTemplate;
 
 extern std::vector<std::string> g_BlacklistCommands;
 
-extern std::string g_DefaultPersonalityPrompt;
+extern std::string      g_DefaultPersonalityPrompt;
 
 extern std::vector<std::string> g_EnvCommentCreature;
 extern std::vector<std::string> g_EnvCommentGameObject;


### PR DESCRIPTION
## [mod-ollama-chat] Add full Ollama generation parameter support via config

### Summary

This PR adds support for configuring all standard Ollama generation parameters via the module’s config file, enabling fine control of model output, context window, and chat structure. All new parameters are configurable, have clear defaults, and are included in API calls only when explicitly set.

---

### **Added Features**

- **Configurable Ollama generation parameters via worldserver.conf:**
  - `OllamaChat.Temperature` (float): Controls randomness/creativity of output
  - `OllamaChat.TopP` (float): Nucleus sampling for randomness
  - `OllamaChat.RepeatPenalty` (float): Penalizes token repetition
  - `OllamaChat.NumCtx` (uint32): Context window size in tokens (0 for model default)
  - `OllamaChat.NumPredict` (uint32): Max tokens generated (0 for unlimited)
  - `OllamaChat.Stop` (string): Comma-separated stop sequences to halt generation
  - `OllamaChat.SystemPrompt` (string): System prompt to globally steer model behavior
  - `OllamaChat.Seed` (string): Deterministic output for reproducibility

- **All parameters documented in `.dist` file with usage instructions and examples.**
- **Configuration loading and global variable management:**
  - All new options loaded in `LoadOllamaChatConfig()`
  - Proper globals declared in header and defined in source
- **API JSON payload only includes non-default, explicitly set values.**
- **Stop sequences are parsed as comma-separated values and sent as an array.**

---

### **Code Changes**

- **`mod-ollama-chat_config.h`**
  - Added new global variables for each Ollama option (temperature, topp, penalty, num_ctx, num_predict, stop, system, seed)

- **`mod-ollama-chat_config.cpp`**
  - Defined all new globals with correct defaults
  - Added config loading code in `LoadOllamaChatConfig()` for each variable

- **`mod-ollama-chat_api.cpp`**
  - Updated API JSON construction:
    - Each Ollama parameter included only if set (not default)
    - Stop parameter parsed to a string array if set

---

### **Usage Example in worldserver.conf.dist**

```ini
# OllamaChat.Temperature = 0.8
# OllamaChat.TopP = 0.95
# OllamaChat.RepeatPenalty = 1.1
# OllamaChat.NumCtx = 0
# OllamaChat.NumPredict = 0
# OllamaChat.Stop =
# OllamaChat.SystemPrompt =
# OllamaChat.Seed =
