### PR TITLE
[DRAFT] Initial commit for Sentiment Tracking feature

### DIFF
--- a/SENTIMENT_TRACKING_DOCUMENTATION.md
+++ b/SENTIMENT_TRACKING_DOCUMENTATION.md
@@ -1,0 +1,209 @@
+# Bot-Player Sentiment Tracking System
+
+This document describes the new sentiment tracking system implemented in mod-ollama-chat, which allows bots to develop persistent relationships with players based on their interactions.
+
+## Overview
+
+The sentiment tracking system enables bots to remember how players treat them over time and adjust their behavior accordingly. Bots become more friendly toward players who are nice to them, and more hostile toward players who are rude or aggressive.
+
+## How It Works
+
+### Sentiment Values
+- Each bot-player relationship has a sentiment value between **0.0** and **1.0**
+- **0.0** = Extremely hostile/negative relationship
+- **0.5** = Neutral relationship (default for new interactions)
+- **1.0** = Extremely friendly/positive relationship
+
+### Sentiment Analysis
+1. When a player sends a message to a bot, the system analyzes the message sentiment using the LLM
+2. The LLM classifies the message as POSITIVE, NEGATIVE, or NEUTRAL
+3. The bot's sentiment toward that player is adjusted accordingly:
+   - POSITIVE messages increase sentiment by the configured adjustment strength
+   - NEGATIVE messages decrease sentiment by the configured adjustment strength
+   - NEUTRAL messages cause no change
+
+### Sentiment Integration
+- Sentiment information is automatically included in bot prompts
+- Bots receive context like: "Your relationship sentiment with PlayerName is 0.8 (0.0=hostile, 0.5=neutral, 1.0=friendly). Use this to guide your tone and response."
+- This allows bots to respond with appropriate warmth, coldness, or neutrality based on history
+
+## Database Schema
+
+The system creates a new table: `mod_ollama_bot_player_sentiments`
+
+```sql
+CREATE TABLE IF NOT EXISTS mod_ollama_bot_player_sentiments (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    bot_guid BIGINT UNSIGNED NOT NULL,
+    player_guid BIGINT UNSIGNED NOT NULL,
+    sentiment_value FLOAT NOT NULL DEFAULT 0.5,
+    last_updated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_sentiment (bot_guid, player_guid)
+);
+```
+
+## Configuration
+
+Add these settings to your `mod_ollama_chat.conf` file:
+
+```ini
+# Enable sentiment tracking (default: 1)
+OllamaChat.EnableSentimentTracking = 1
+
+# Default sentiment for new relationships (default: 0.5)
+OllamaChat.SentimentDefaultValue = 0.5
+
+# How much to adjust sentiment per message (default: 0.1)
+OllamaChat.SentimentAdjustmentStrength = 0.1
+
+# How often to save sentiment data in minutes (default: 10)
+OllamaChat.SentimentSaveInterval = 10
+
+# Prompt for sentiment analysis
+OllamaChat.SentimentAnalysisPrompt = "Analyze the sentiment of this message: \"{message}\". Respond only with: POSITIVE, NEGATIVE, or NEUTRAL."
+
+# Template for including sentiment in bot prompts
+OllamaChat.SentimentPromptTemplate = "Your relationship sentiment with {player_name} is {sentiment_value} (0.0=hostile, 0.5=neutral, 1.0=friendly). Use this to guide your tone and response."
+```
+
+### Important: Update Your Prompt Templates
+
+Make sure your chat and event prompt templates include the `{sentiment_info}` placeholder:
+
+```ini
+# Example chat template with sentiment
+OllamaChat.ChatPromptTemplate = "You are {bot_name}, a {bot_class} bot. {bot_personality} {sentiment_info} Player {player_name} says: {player_message}"
+
+# Example event template with sentiment  
+OllamaChat.EventChatterPromptTemplate = "You are {bot_name}, a {bot_class} bot. {bot_personality} {sentiment_info} React to this event: {event_type} involving {actor_name}"
+```
+
+## Admin Commands
+
+The system provides several admin commands for managing sentiment data:
+
+### View Sentiment Data
+```
+.ollama sentiment view [botname] [playername]
+```
+- No arguments: Shows all sentiment data
+- Bot name only: Shows all sentiments for that bot
+- Player name only: Shows all sentiments involving that player  
+- Both names: Shows specific bot-player sentiment
+
+### Set Sentiment Value
+```
+.ollama sentiment set <botname> <playername> <value>
+```
+- Manually sets sentiment between a bot and player
+- Value must be between 0.0 and 1.0
+
+### Reset Sentiment Data
+```
+.ollama sentiment reset [botname] [playername]
+```
+- No arguments: Resets ALL sentiment data
+- Bot name only: Resets all sentiments for that bot
+- Player name only: Resets all sentiments involving that player
+- Both names: Resets specific bot-player sentiment to default
+
+## Performance Considerations
+
+### Memory Usage
+- Sentiment data is cached in memory for fast access
+- Data is periodically saved to database (configurable interval)
+- Memory usage scales with number of unique bot-player interactions
+
+### LLM Load
+- Each player message triggers an additional LLM call for sentiment analysis
+- Consider your LLM server capacity when enabling this feature
+- Sentiment analysis uses a simple prompt and expects short responses
+
+### Database Load
+- Sentiment data is batched and saved periodically
+- Uses REPLACE INTO for efficient upserts
+- Minimal database impact with reasonable save intervals
+
+## Examples
+
+### Example Interaction Flow
+
+1. **First Interaction**: Player "Alice" says "Hello there!" to bot "BotTank"
+   - No existing sentiment → starts at 0.5 (neutral)
+   - Message analyzed as POSITIVE
+   - Sentiment increases to 0.6
+   - Bot responds neutrally/positively
+
+2. **Positive Interaction**: Alice says "You're the best tank ever!"
+   - Current sentiment: 0.6
+   - Message analyzed as POSITIVE  
+   - Sentiment increases to 0.7
+   - Bot responds more warmly
+
+3. **Negative Interaction**: Alice says "You suck at tanking!"
+   - Current sentiment: 0.7
+   - Message analyzed as NEGATIVE
+   - Sentiment decreases to 0.6
+   - Bot response becomes cooler
+
+### Example Bot Responses Based on Sentiment
+
+**High Sentiment (0.8+)**:
+- "Hey Alice, great to see you again!"
+- "Always happy to help you out!"
+- Enthusiastic, helpful tone
+
+**Neutral Sentiment (0.4-0.6)**:
+- "Hello Alice."
+- "Sure, I can help with that."
+- Polite but not enthusiastic
+
+**Low Sentiment (0.2-)**:
+- "What do you want?"
+- "I suppose I could help..."
+- Cold, reluctant tone
+
+## Troubleshooting
+
+### Sentiment Not Updating
+1. Check that `OllamaChat.EnableSentimentTracking = 1`
+2. Verify your LLM is responding correctly to sentiment analysis prompts
+3. Check server logs for sentiment analysis debug messages
+4. Ensure your chat templates include `{sentiment_info}` placeholder
+
+### Performance Issues
+1. Increase `OllamaChat.SentimentSaveInterval` to reduce database writes
+2. Consider reducing `OllamaChat.SentimentAdjustmentStrength` for fewer LLM calls
+3. Monitor your LLM server load
+
+### Database Issues
+1. Ensure the sentiment table was created properly
+2. Check database permissions for the characters database
+3. Verify database connection in server logs
+
+## Technical Implementation Details
+
+### Files Added/Modified
+- `mod-ollama-chat_sentiment.h` - Sentiment system header
+- `mod-ollama-chat_sentiment.cpp` - Sentiment system implementation  
+- `mod-ollama-chat_config.h` - Added sentiment configuration variables
+- `mod-ollama-chat_config.cpp` - Added sentiment config loading
+- `mod-ollama-chat_handler.cpp` - Integrated sentiment into chat processing
+- `mod-ollama-chat_events.cpp` - Integrated sentiment into event system
+- `mod-ollama-chat_command.h/.cpp` - Added sentiment admin commands
+- `mod-ollama-chat_random.cpp` - Added sentiment periodic saving
+- `2025_07_25_sentiment_tracking.sql` - Database schema
+
+### Thread Safety
+- All sentiment data access is protected by mutex locks
+- Sentiment analysis runs in background threads
+- Database operations are batched for efficiency
+
+### Integration Points
+1. **Chat Handler**: Sentiment analysis and updates happen during chat processing
+2. **Event System**: Event prompts include sentiment context when actor is a player
+3. **Prompt Generation**: All bot prompts automatically include sentiment information
+4. **Periodic Saves**: Sentiment data is saved alongside conversation history
+
+This system provides a persistent, evolving relationship dynamic that makes bot interactions feel more personal and reactive to player behavior over time.

--- a/conf/mod_ollama_chat.conf.dist
+++ b/conf/mod_ollama_chat.conf.dist
@@ -236,8 +236,8 @@ OllamaChat.EventChatterMaxBotsPerPlayer = 2
 
 # OllamaChat.EventChatterPromptTemplate
 #     Description: The template used to generate bot prompts when reacting to world events.
-#     Placeholders (named): {bot_name} {bot_level} {bot_class} {bot_race} {bot_gender} {bot_role} {bot_faction} {bot_area} {bot_zone} {bot_map} {bot_personality} {event_type} {event_detail} {actor_name}
-OllamaChat.EventChatterPromptTemplate = "You are {bot_name}, a level {bot_level} {bot_class} ({bot_race} {bot_gender}) specializing as a {bot_role} from the {bot_faction} faction. You are currently in {bot_area}, Zone: {bot_zone}, Map: {bot_map}. Personality: {bot_personality}. Event: {actor_name} {event_type} {event_detail}. Respond to this specific Event that just happened in character, casually, in under 15 words. Avoid emojis, markdown, or narration."
+#     Placeholders (named): {bot_name} {bot_level} {bot_class} {bot_race} {bot_gender} {bot_role} {bot_faction} {bot_area} {bot_zone} {bot_map} {bot_personality} {event_type} {event_detail} {actor_name} {sentiment_info}
+OllamaChat.EventChatterPromptTemplate = "You are {bot_name}, a level {bot_level} {bot_class} ({bot_race} {bot_gender}) specializing as a {bot_role} from the {bot_faction} faction. You are currently in {bot_area}, Zone: {bot_zone}, Map: {bot_map}. Personality: {bot_personality}. {sentiment_info} Event: {actor_name} {event_type} {event_detail}. Respond to this specific Event that just happened in character, casually, in under 15 words. Avoid emojis, markdown, or narration."
 
 # --------------------------------------------
 # RP PERSONALITIES SYSTEM
@@ -307,7 +307,7 @@ OllamaChat.ChatHistoryFooterTemplate = "NEW MESSAGE from {player_name}: {player_
 OllamaChat.ChatBotSnapshotTemplate = "CURRENT CONTEXT:\n{combat}\n{group}\nSpells:\n{spells}\nQuests:\n{quests}\nVisible Objects:\n{los}\nNearby Players:\n{players}"
 
 # ----------------------------------------------
-# Bot-Player Sentiment Tracking System
+# SENTIMENT TRACKING SYSTEM
 # ----------------------------------------------
 
 # Enable or disable sentiment tracking between bots and players
@@ -321,8 +321,8 @@ OllamaChat.SentimentDefaultValue = 0.5
 
 # How much to adjust sentiment per positive/negative message
 # Range: 0.01 to 0.5 (smaller = more gradual changes)
-# Default: 0.1
-OllamaChat.SentimentAdjustmentStrength = 0.1
+# Default: 0.05
+OllamaChat.SentimentAdjustmentStrength = 0.05
 
 # How often to save sentiment data to database (in minutes)
 # Set to 0 to disable periodic saving
@@ -339,18 +339,14 @@ OllamaChat.SentimentAnalysisPrompt = "Analyze the sentiment of this message: \"{
 # Default: "Your relationship sentiment with {player_name} is {sentiment_value} (0.0=hostile, 0.5=neutral, 1.0=friendly). Use this to guide your tone and response."
 OllamaChat.SentimentPromptTemplate = "Your relationship sentiment with {player_name} is {sentiment_value} (0.0=hostile, 0.5=neutral, 1.0=friendly). Use this to guide your tone and response."
 
-# Note: Make sure your chat and event prompt templates include the {sentiment_info} placeholder
-# Example chat template:
-# OllamaChat.ChatPromptTemplate = "You are {bot_name}, a {bot_class} bot. {bot_personality} {sentiment_info} Player {player_name} says: {player_message}"
-
 # --------------------------------------------
 # CHAT/PROMPT TEMPLATES
 # --------------------------------------------
 
 # OllamaChat.ChatPromptTemplate
 #   Description: The main template for bot chat prompts sent to the LLM.
-#   Placeholders (named): {bot_name} {bot_level} {bot_class} {bot_personality} {player_level} {player_class} {player_name} {player_message} {extra_info}
-OllamaChat.ChatPromptTemplate = "You're a Wrath-era WoW player familiar with Vanilla and TBC. Name: {bot_name}, Level: {bot_level} {bot_class}, MAKE SURE YOU RESPOND USING YOUR PERSONALITY, WHICH IS: {bot_personality}. A level {player_level} {player_class} named {player_name} said: '{player_message}'. {extra_info} Reply naturally in under 15 words. Use authentic WoW tone. Respect higher levels, mock lower ones. Be blunt if provoked. Be precise if giving directions. Never contradict your class, race, or location. Never act like a narrator—just respond like a player."
+#   Placeholders (named): {bot_name} {bot_level} {bot_class} {bot_personality} {player_level} {player_class} {player_name} {player_message} {extra_info} {sentiment_info}
+OllamaChat.ChatPromptTemplate = "You're a Wrath-era WoW player familiar with Vanilla and TBC. Name: {bot_name}, Level: {bot_level} {bot_class}, MAKE SURE YOU RESPOND USING YOUR PERSONALITY, WHICH IS: {bot_personality}. {sentiment_info} A level {player_level} {player_class} named {player_name} said: '{player_message}'. {extra_info} Reply naturally in under 15 words. Use authentic WoW tone. Respect higher levels, mock lower ones. Be blunt if provoked. Be precise if giving directions. Never contradict your class, race, or location. Never act like a narrator—just respond like a player."
 
 # OllamaChat.ChatExtraInfoTemplate
 #   Description: The context/details string about the bot and player, injected into the chat prompt as the last parameter.

--- a/conf/mod_ollama_chat.conf.dist
+++ b/conf/mod_ollama_chat.conf.dist
@@ -306,6 +306,43 @@ OllamaChat.ChatHistoryFooterTemplate = "NEW MESSAGE from {player_name}: {player_
 #   Placeholders (named): {combat} {group} {spells} {quests} {los} {players}
 OllamaChat.ChatBotSnapshotTemplate = "CURRENT CONTEXT:\n{combat}\n{group}\nSpells:\n{spells}\nQuests:\n{quests}\nVisible Objects:\n{los}\nNearby Players:\n{players}"
 
+# ----------------------------------------------
+# Bot-Player Sentiment Tracking System
+# ----------------------------------------------
+
+# Enable or disable sentiment tracking between bots and players
+# Default: 1 (enabled)
+OllamaChat.EnableSentimentTracking = 1
+
+# Default sentiment value for new bot-player relationships
+# Range: 0.0 (hostile) to 1.0 (friendly), 0.5 = neutral
+# Default: 0.5
+OllamaChat.SentimentDefaultValue = 0.5
+
+# How much to adjust sentiment per positive/negative message
+# Range: 0.01 to 0.5 (smaller = more gradual changes)
+# Default: 0.1
+OllamaChat.SentimentAdjustmentStrength = 0.1
+
+# How often to save sentiment data to database (in minutes)
+# Set to 0 to disable periodic saving
+# Default: 10
+OllamaChat.SentimentSaveInterval = 10
+
+# Prompt template for sentiment analysis
+# Use {message} placeholder for the message to analyze
+# Default: "Analyze the sentiment of this message: \"{message}\". Respond only with: POSITIVE, NEGATIVE, or NEUTRAL."
+OllamaChat.SentimentAnalysisPrompt = "Analyze the sentiment of this message: \"{message}\". Respond only with: POSITIVE, NEGATIVE, or NEUTRAL."
+
+# Template for including sentiment information in bot prompts
+# Use {player_name} and {sentiment_value} placeholders
+# Default: "Your relationship sentiment with {player_name} is {sentiment_value} (0.0=hostile, 0.5=neutral, 1.0=friendly). Use this to guide your tone and response."
+OllamaChat.SentimentPromptTemplate = "Your relationship sentiment with {player_name} is {sentiment_value} (0.0=hostile, 0.5=neutral, 1.0=friendly). Use this to guide your tone and response."
+
+# Note: Make sure your chat and event prompt templates include the {sentiment_info} placeholder
+# Example chat template:
+# OllamaChat.ChatPromptTemplate = "You are {bot_name}, a {bot_class} bot. {bot_personality} {sentiment_info} Player {player_name} says: {player_message}"
+
 # --------------------------------------------
 # CHAT/PROMPT TEMPLATES
 # --------------------------------------------

--- a/data/sql/characters/base/2025_07_25_sentiment_tracking.sql
+++ b/data/sql/characters/base/2025_07_25_sentiment_tracking.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS mod_ollama_bot_player_sentiments (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    bot_guid BIGINT UNSIGNED NOT NULL,
+    player_guid BIGINT UNSIGNED NOT NULL,
+    sentiment_value FLOAT NOT NULL DEFAULT 0.5 COMMENT 'Sentiment value: 0.0=hostile, 0.5=neutral, 1.0=friendly',
+    last_updated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- Unique constraint to ensure one sentiment record per bot-player pair
+    UNIQUE KEY unique_sentiment (bot_guid, player_guid),
+    -- Indexes for performance
+    INDEX idx_bot_guid (bot_guid),
+    INDEX idx_player_guid (player_guid),
+    INDEX idx_sentiment_value (sentiment_value)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/mod-ollama-chat_command.cpp
+++ b/src/mod-ollama-chat_command.cpp
@@ -1,7 +1,11 @@
 #include "mod-ollama-chat_command.h"
 #include "mod-ollama-chat_config.h"
+#include "mod-ollama-chat_sentiment.h"
 #include "Chat.h"
 #include "Config.h"
+#include "ObjectAccessor.h"
+#include "Player.h"
+#include "PlayerbotMgr.h"
 
 using namespace Acore::ChatCommands;
 
@@ -12,9 +16,17 @@ OllamaChatConfigCommand::OllamaChatConfigCommand()
 
 ChatCommandTable OllamaChatConfigCommand::GetCommands() const
 {
+    static ChatCommandTable ollamaSentimentCommandTable =
+    {
+        { "view", HandleOllamaSentimentViewCommand, SEC_ADMINISTRATOR, Console::Yes },
+        { "set", HandleOllamaSentimentSetCommand, SEC_ADMINISTRATOR, Console::Yes },
+        { "reset", HandleOllamaSentimentResetCommand, SEC_ADMINISTRATOR, Console::Yes }
+    };
+
     static ChatCommandTable ollamaReloadCommandTable =
     {
-        { "reload", HandleOllamaReloadCommand, SEC_ADMINISTRATOR, Console::Yes }
+        { "reload", HandleOllamaReloadCommand, SEC_ADMINISTRATOR, Console::Yes },
+        { "sentiment", ollamaSentimentCommandTable }
     };
 
     static ChatCommandTable commandTable =
@@ -31,6 +43,269 @@ bool OllamaChatConfigCommand::HandleOllamaReloadCommand(ChatHandler* handler)
     LoadOllamaChatConfig();
     LoadBotPersonalityList();
     LoadBotConversationHistoryFromDB();
+    InitializeSentimentTracking();
     handler->SendSysMessage("OllamaChat: Configuration reloaded from conf!");
+    return true;
+}
+
+bool OllamaChatConfigCommand::HandleOllamaSentimentViewCommand(ChatHandler* handler, Optional<std::string> botName, Optional<std::string> playerName)
+{
+    if (!g_EnableSentimentTracking)
+    {
+        handler->SendSysMessage("OllamaChat: Sentiment tracking is disabled.");
+        return true;
+    }
+
+    if (!botName && !playerName)
+    {
+        // Show all sentiment data
+        std::lock_guard<std::mutex> lock(g_SentimentMutex);
+        if (g_BotPlayerSentiments.empty())
+        {
+            handler->SendSysMessage("OllamaChat: No sentiment data found.");
+            return true;
+        }
+
+        handler->SendSysMessage("OllamaChat: All sentiment data:");
+        for (const auto& [botGuid, playerMap] : g_BotPlayerSentiments)
+        {
+            Player* bot = ObjectAccessor::FindPlayer(ObjectGuid(botGuid));
+            std::string botNameStr = bot ? bot->GetName() : std::to_string(botGuid);
+            
+            for (const auto& [playerGuid, sentiment] : playerMap)
+            {
+                Player* player = ObjectAccessor::FindPlayer(ObjectGuid(playerGuid));
+                std::string playerNameStr = player ? player->GetName() : std::to_string(playerGuid);
+                
+                handler->PSendSysMessage("  Bot '%s' -> Player '%s': %.3f", 
+                                        botNameStr.c_str(), playerNameStr.c_str(), sentiment);
+            }
+        }
+        return true;
+    }
+
+    // Find specific bot or player
+    Player* targetBot = nullptr;
+    Player* targetPlayer = nullptr;
+
+    if (botName)
+    {
+        targetBot = ObjectAccessor::FindPlayerByName(*botName);
+        if (!targetBot)
+        {
+            handler->PSendSysMessage("OllamaChat: Bot '%s' not found.", botName->c_str());
+            return true;
+        }
+        if (!sPlayerbotsMgr->GetPlayerbotAI(targetBot))
+        {
+            handler->PSendSysMessage("OllamaChat: Player '%s' is not a bot.", botName->c_str());
+            return true;
+        }
+    }
+
+    if (playerName)
+    {
+        targetPlayer = ObjectAccessor::FindPlayerByName(*playerName);
+        if (!targetPlayer)
+        {
+            handler->PSendSysMessage("OllamaChat: Player '%s' not found.", playerName->c_str());
+            return true;
+        }
+    }
+
+    // Show sentiment for specific bot-player pair or all pairs involving a specific bot/player
+    if (targetBot && targetPlayer)
+    {
+        float sentiment = GetBotPlayerSentiment(targetBot->GetGUID().GetRawValue(), targetPlayer->GetGUID().GetRawValue());
+        handler->PSendSysMessage("OllamaChat: Bot '%s' -> Player '%s': %.3f", 
+                                targetBot->GetName().c_str(), targetPlayer->GetName().c_str(), sentiment);
+    }
+    else if (targetBot)
+    {
+        // Show all sentiments for this bot
+        uint64_t botGuid = targetBot->GetGUID().GetRawValue();
+        std::lock_guard<std::mutex> lock(g_SentimentMutex);
+        
+        auto botIt = g_BotPlayerSentiments.find(botGuid);
+        if (botIt == g_BotPlayerSentiments.end() || botIt->second.empty())
+        {
+            handler->PSendSysMessage("OllamaChat: No sentiment data found for bot '%s'.", targetBot->GetName().c_str());
+            return true;
+        }
+
+        handler->PSendSysMessage("OllamaChat: Sentiment data for bot '%s':", targetBot->GetName().c_str());
+        for (const auto& [playerGuid, sentiment] : botIt->second)
+        {
+            Player* player = ObjectAccessor::FindPlayer(ObjectGuid(playerGuid));
+            std::string playerNameStr = player ? player->GetName() : std::to_string(playerGuid);
+            handler->PSendSysMessage("  -> Player '%s': %.3f", playerNameStr.c_str(), sentiment);
+        }
+    }
+    else if (targetPlayer)
+    {
+        // Show all sentiments involving this player
+        uint64_t playerGuid = targetPlayer->GetGUID().GetRawValue();
+        std::lock_guard<std::mutex> lock(g_SentimentMutex);
+        
+        bool found = false;
+        handler->PSendSysMessage("OllamaChat: Sentiment data involving player '%s':", targetPlayer->GetName().c_str());
+        
+        for (const auto& [botGuid, playerMap] : g_BotPlayerSentiments)
+        {
+            auto playerIt = playerMap.find(playerGuid);
+            if (playerIt != playerMap.end())
+            {
+                Player* bot = ObjectAccessor::FindPlayer(ObjectGuid(botGuid));
+                std::string botNameStr = bot ? bot->GetName() : std::to_string(botGuid);
+                handler->PSendSysMessage("  Bot '%s' -> %.3f", botNameStr.c_str(), playerIt->second);
+                found = true;
+            }
+        }
+        
+        if (!found)
+        {
+            handler->PSendSysMessage("OllamaChat: No sentiment data found involving player '%s'.", targetPlayer->GetName().c_str());
+        }
+    }
+
+    return true;
+}
+
+bool OllamaChatConfigCommand::HandleOllamaSentimentSetCommand(ChatHandler* handler, std::string botName, std::string playerName, float sentimentValue)
+{
+    if (!g_EnableSentimentTracking)
+    {
+        handler->SendSysMessage("OllamaChat: Sentiment tracking is disabled.");
+        return true;
+    }
+
+    Player* bot = ObjectAccessor::FindPlayerByName(botName);
+    if (!bot)
+    {
+        handler->PSendSysMessage("OllamaChat: Bot '%s' not found.", botName.c_str());
+        return true;
+    }
+    if (!sPlayerbotsMgr->GetPlayerbotAI(bot))
+    {
+        handler->PSendSysMessage("OllamaChat: Player '%s' is not a bot.", botName.c_str());
+        return true;
+    }
+
+    Player* player = ObjectAccessor::FindPlayerByName(playerName);
+    if (!player)
+    {
+        handler->PSendSysMessage("OllamaChat: Player '%s' not found.", playerName.c_str());
+        return true;
+    }
+
+    if (sentimentValue < 0.0f || sentimentValue > 1.0f)
+    {
+        handler->SendSysMessage("OllamaChat: Sentiment value must be between 0.0 and 1.0.");
+        return true;
+    }
+
+    SetBotPlayerSentiment(bot->GetGUID().GetRawValue(), player->GetGUID().GetRawValue(), sentimentValue);
+    handler->PSendSysMessage("OllamaChat: Set sentiment between bot '%s' and player '%s' to %.3f.", 
+                            botName.c_str(), playerName.c_str(), sentimentValue);
+    return true;
+}
+
+bool OllamaChatConfigCommand::HandleOllamaSentimentResetCommand(ChatHandler* handler, Optional<std::string> botName, Optional<std::string> playerName)
+{
+    if (!g_EnableSentimentTracking)
+    {
+        handler->SendSysMessage("OllamaChat: Sentiment tracking is disabled.");
+        return true;
+    }
+
+    if (!botName && !playerName)
+    {
+        // Reset all sentiment data
+        std::lock_guard<std::mutex> lock(g_SentimentMutex);
+        uint32_t count = 0;
+        for (const auto& [botGuid, playerMap] : g_BotPlayerSentiments)
+        {
+            count += playerMap.size();
+        }
+        g_BotPlayerSentiments.clear();
+        handler->PSendSysMessage("OllamaChat: Reset all sentiment data (%u records).", count);
+        return true;
+    }
+
+    Player* targetBot = nullptr;
+    Player* targetPlayer = nullptr;
+
+    if (botName)
+    {
+        targetBot = ObjectAccessor::FindPlayerByName(*botName);
+        if (!targetBot)
+        {
+            handler->PSendSysMessage("OllamaChat: Bot '%s' not found.", botName->c_str());
+            return true;
+        }
+        if (!sPlayerbotsMgr->GetPlayerbotAI(targetBot))
+        {
+            handler->PSendSysMessage("OllamaChat: Player '%s' is not a bot.", botName->c_str());
+            return true;
+        }
+    }
+
+    if (playerName)
+    {
+        targetPlayer = ObjectAccessor::FindPlayerByName(*playerName);
+        if (!targetPlayer)
+        {
+            handler->PSendSysMessage("OllamaChat: Player '%s' not found.", playerName->c_str());
+            return true;
+        }
+    }
+
+    if (targetBot && targetPlayer)
+    {
+        // Reset specific bot-player sentiment
+        SetBotPlayerSentiment(targetBot->GetGUID().GetRawValue(), targetPlayer->GetGUID().GetRawValue(), g_SentimentDefaultValue);
+        handler->PSendSysMessage("OllamaChat: Reset sentiment between bot '%s' and player '%s' to default (%.3f).", 
+                                targetBot->GetName().c_str(), targetPlayer->GetName().c_str(), g_SentimentDefaultValue);
+    }
+    else if (targetBot)
+    {
+        // Reset all sentiments for this bot
+        uint64_t botGuid = targetBot->GetGUID().GetRawValue();
+        std::lock_guard<std::mutex> lock(g_SentimentMutex);
+        
+        auto botIt = g_BotPlayerSentiments.find(botGuid);
+        if (botIt != g_BotPlayerSentiments.end())
+        {
+            uint32_t count = botIt->second.size();
+            g_BotPlayerSentiments.erase(botIt);
+            handler->PSendSysMessage("OllamaChat: Reset all sentiment data for bot '%s' (%u records).", 
+                                    targetBot->GetName().c_str(), count);
+        }
+        else
+        {
+            handler->PSendSysMessage("OllamaChat: No sentiment data found for bot '%s'.", targetBot->GetName().c_str());
+        }
+    }
+    else if (targetPlayer)
+    {
+        // Reset all sentiments involving this player
+        uint64_t playerGuid = targetPlayer->GetGUID().GetRawValue();
+        std::lock_guard<std::mutex> lock(g_SentimentMutex);
+        
+        uint32_t count = 0;
+        for (auto& [botGuid, playerMap] : g_BotPlayerSentiments)
+        {
+            auto playerIt = playerMap.find(playerGuid);
+            if (playerIt != playerMap.end())
+            {
+                playerMap.erase(playerIt);
+                count++;
+            }
+        }
+        
+        handler->PSendSysMessage("OllamaChat: Reset all sentiment data involving player '%s' (%u records).", 
+                                targetPlayer->GetName().c_str(), count);
+    }
+
     return true;
 }

--- a/src/mod-ollama-chat_command.h
+++ b/src/mod-ollama-chat_command.h
@@ -10,7 +10,10 @@ public:
     OllamaChatConfigCommand();
     Acore::ChatCommands::ChatCommandTable GetCommands() const override;
 
-    static bool HandleOllamaReloadCommand(ChatHandler* handler); // Added static method declaration
+    static bool HandleOllamaReloadCommand(ChatHandler* handler);
+    static bool HandleOllamaSentimentViewCommand(ChatHandler* handler, Optional<std::string> botName, Optional<std::string> playerName);
+    static bool HandleOllamaSentimentSetCommand(ChatHandler* handler, std::string botName, std::string playerName, float sentimentValue);
+    static bool HandleOllamaSentimentResetCommand(ChatHandler* handler, Optional<std::string> botName, Optional<std::string> playerName);
 };
 
 #endif // MOD_OLLAMA_CHAT_COMMAND_H

--- a/src/mod-ollama-chat_config.h
+++ b/src/mod-ollama-chat_config.h
@@ -136,6 +136,21 @@ extern std::vector<std::string> g_EnvCommentDungeon;
 extern std::vector<std::string> g_EnvCommentUnfinishedQuest;
 
 // --------------------------------------------
+// Bot-Player Sentiment Tracking System
+// --------------------------------------------
+extern bool        g_EnableSentimentTracking;
+extern float       g_SentimentDefaultValue;              // Default sentiment value (0.5 = neutral)
+extern float       g_SentimentAdjustmentStrength;        // How much to adjust sentiment per message (0.1)
+extern uint32_t    g_SentimentSaveInterval;              // How often to save sentiment to DB (minutes)
+extern std::string g_SentimentAnalysisPrompt;            // Prompt template for sentiment analysis
+extern std::string g_SentimentPromptTemplate;            // Template for including sentiment in bot prompts
+
+// In-memory sentiment storage and mutex
+extern std::unordered_map<uint64_t, std::unordered_map<uint64_t, float>> g_BotPlayerSentiments;
+extern std::mutex g_SentimentMutex;
+extern time_t g_LastSentimentSaveTime;
+
+// --------------------------------------------
 // Event Chatter: Event Type Strings
 // These control the event type string sent to eventChatter for world event prompts.
 // Values are loaded from conf (see mod_ollama_chat.conf.dist)

--- a/src/mod-ollama-chat_events.cpp
+++ b/src/mod-ollama-chat_events.cpp
@@ -4,6 +4,7 @@
 #include "mod-ollama-chat_api.h"
 #include "mod-ollama-chat-utilities.h"
 #include "mod-ollama-chat_personality.h"
+#include "mod-ollama-chat_sentiment.h"
 #include "Player.h"
 #include "ObjectAccessor.h"
 #include "Guild.h"
@@ -181,6 +182,18 @@ std::string OllamaBotEventChatter::BuildPrompt(Player* bot, std::string promptTe
     std::string botZoneName = botCurrentZone ? ai->GetLocalizedAreaName(botCurrentZone) : "UnknownZone";
     std::string botMapName = bot->GetMap() ? bot->GetMap()->GetMapName() : "UnknownMap";
 
+    // Try to get sentiment information if the actor is a player
+    std::string sentimentInfo = "";
+    if (g_EnableSentimentTracking && !actorName.empty())
+    {
+        // Try to find the actor player by name
+        Player* actorPlayer = ObjectAccessor::FindPlayerByName(actorName);
+        if (actorPlayer)
+        {
+            sentimentInfo = GetSentimentPromptAddition(bot, actorPlayer);
+        }
+    }
+
     return SafeFormat(
         promptTemplate,
         fmt::arg("bot_name", botName),
@@ -196,7 +209,8 @@ std::string OllamaBotEventChatter::BuildPrompt(Player* bot, std::string promptTe
         fmt::arg("bot_personality", personalityPrompt),
         fmt::arg("event_type", eventType),
         fmt::arg("event_detail", eventDetail),
-        fmt::arg("actor_name", actorName)
+        fmt::arg("actor_name", actorName),
+        fmt::arg("sentiment_info", sentimentInfo)
     );
 }
 

--- a/src/mod-ollama-chat_random.cpp
+++ b/src/mod-ollama-chat_random.cpp
@@ -1,6 +1,7 @@
 #include "mod-ollama-chat_random.h"
 #include "mod-ollama-chat_config.h"
 #include "mod-ollama-chat_handler.h"
+#include "mod-ollama-chat_sentiment.h"
 #include "Log.h"
 #include "Player.h"
 #include "PlayerbotAI.h"
@@ -42,6 +43,17 @@ void OllamaBotRandomChatter::OnUpdate(uint32 diff)
         {
             SaveBotConversationHistoryToDB();
             g_LastHistorySaveTime = now;
+        }
+    }
+
+    // Save sentiment data periodically
+    if (g_EnableSentimentTracking && g_SentimentSaveInterval > 0)
+    {
+        time_t now = time(nullptr);
+        if (difftime(now, g_LastSentimentSaveTime) >= g_SentimentSaveInterval * 60)
+        {
+            SaveBotPlayerSentimentsToDB();
+            g_LastSentimentSaveTime = now;
         }
     }
 

--- a/src/mod-ollama-chat_sentiment.cpp
+++ b/src/mod-ollama-chat_sentiment.cpp
@@ -1,0 +1,220 @@
+#include "mod-ollama-chat_sentiment.h"
+#include "mod-ollama-chat_config.h"
+#include "mod-ollama-chat_api.h"
+#include "mod-ollama-chat-utilities.h"
+#include "Log.h"
+#include "DatabaseEnv.h"
+#include "Player.h"
+#include <fmt/core.h>
+#include <algorithm>
+#include <mutex>
+
+float GetBotPlayerSentiment(uint64_t botGuid, uint64_t playerGuid)
+{
+    if (!g_EnableSentimentTracking)
+        return g_SentimentDefaultValue;
+
+    std::lock_guard<std::mutex> lock(g_SentimentMutex);
+    
+    auto botIt = g_BotPlayerSentiments.find(botGuid);
+    if (botIt != g_BotPlayerSentiments.end())
+    {
+        auto playerIt = botIt->second.find(playerGuid);
+        if (playerIt != botIt->second.end())
+        {
+            return playerIt->second;
+        }
+    }
+    
+    // Return default value if not found
+    return g_SentimentDefaultValue;
+}
+
+void SetBotPlayerSentiment(uint64_t botGuid, uint64_t playerGuid, float sentimentValue)
+{
+    if (!g_EnableSentimentTracking)
+        return;
+
+    // Clamp sentiment value to valid range [0.0, 1.0]
+    sentimentValue = std::max(0.0f, std::min(1.0f, sentimentValue));
+    
+    std::lock_guard<std::mutex> lock(g_SentimentMutex);
+    g_BotPlayerSentiments[botGuid][playerGuid] = sentimentValue;
+    
+    if (g_DebugEnabled)
+    {
+        LOG_INFO("server.loading", "[OllamaChat] Set sentiment between bot {} and player {} to {:.2f}", 
+                 botGuid, playerGuid, sentimentValue);
+    }
+}
+
+float AnalyzeMessageSentiment(const std::string& message)
+{
+    if (!g_EnableSentimentTracking || message.empty())
+        return 0.0f;
+
+    // Format the sentiment analysis prompt
+    std::string prompt = SafeFormat(g_SentimentAnalysisPrompt, fmt::arg("message", message));
+    
+    if (g_DebugEnabled)
+    {
+        LOG_INFO("server.loading", "[OllamaChat] Sentiment analysis prompt: {}", prompt);
+    }
+    
+    // Query the LLM for sentiment analysis
+    std::string response = QueryOllamaAPI(prompt);
+    
+    if (response.empty())
+    {
+        if (g_DebugEnabled)
+            LOG_INFO("server.loading", "[OllamaChat] Empty sentiment analysis response");
+        return 0.0f;
+    }
+    
+    // Convert response to uppercase for comparison
+    std::string upperResponse = response;
+    std::transform(upperResponse.begin(), upperResponse.end(), upperResponse.begin(), ::toupper);
+    
+    // Parse the sentiment response
+    float adjustment = 0.0f;
+    if (upperResponse.find("POSITIVE") != std::string::npos)
+    {
+        adjustment = g_SentimentAdjustmentStrength;
+    }
+    else if (upperResponse.find("NEGATIVE") != std::string::npos)
+    {
+        adjustment = -g_SentimentAdjustmentStrength;
+    }
+    // NEUTRAL or unrecognized = 0.0f (no change)
+    
+    if (g_DebugEnabled)
+    {
+        LOG_INFO("server.loading", "[OllamaChat] Sentiment analysis: '{}' -> adjustment: {:.2f}", 
+                 response, adjustment);
+    }
+    
+    return adjustment;
+}
+
+void UpdateBotPlayerSentiment(Player* bot, Player* player, const std::string& message)
+{
+    if (!g_EnableSentimentTracking || !bot || !player)
+        return;
+
+    uint64_t botGuid = bot->GetGUID().GetRawValue();
+    uint64_t playerGuid = player->GetGUID().GetRawValue();
+    
+    // Get current sentiment
+    float currentSentiment = GetBotPlayerSentiment(botGuid, playerGuid);
+    
+    // Analyze the message sentiment
+    float adjustment = AnalyzeMessageSentiment(message);
+    
+    // Apply the adjustment
+    float newSentiment = currentSentiment + adjustment;
+    
+    // Set the updated sentiment
+    SetBotPlayerSentiment(botGuid, playerGuid, newSentiment);
+    
+    if (g_DebugEnabled && adjustment != 0.0f)
+    {
+        LOG_INFO("server.loading", "[OllamaChat] Updated sentiment: {} -> {} ({:+.2f}) for bot {} and player {}", 
+                 currentSentiment, newSentiment, adjustment, bot->GetName(), player->GetName());
+    }
+}
+
+std::string GetSentimentPromptAddition(Player* bot, Player* player)
+{
+    if (!g_EnableSentimentTracking || !bot || !player || g_SentimentPromptTemplate.empty())
+        return "";
+
+    uint64_t botGuid = bot->GetGUID().GetRawValue();
+    uint64_t playerGuid = player->GetGUID().GetRawValue();
+    
+    float sentimentValue = GetBotPlayerSentiment(botGuid, playerGuid);
+    
+    return SafeFormat(
+        g_SentimentPromptTemplate,
+        fmt::arg("player_name", player->GetName()),
+        fmt::arg("sentiment_value", sentimentValue)
+    );
+}
+
+void LoadBotPlayerSentimentsFromDB()
+{
+    if (!g_EnableSentimentTracking)
+        return;
+
+    std::lock_guard<std::mutex> lock(g_SentimentMutex);
+    g_BotPlayerSentiments.clear();
+    
+    QueryResult result = CharacterDatabase.Query("SELECT bot_guid, player_guid, sentiment_value FROM mod_ollama_bot_player_sentiments");
+    
+    if (!result)
+    {
+        LOG_INFO("server.loading", "[OllamaChat] No existing sentiment data found in database");
+        return;
+    }
+    
+    uint32_t count = 0;
+    do
+    {
+        Field* fields = result->Fetch();
+        uint64_t botGuid = fields[0].Get<uint64_t>();
+        uint64_t playerGuid = fields[1].Get<uint64_t>();
+        float sentimentValue = fields[2].Get<float>();
+        
+        g_BotPlayerSentiments[botGuid][playerGuid] = sentimentValue;
+        count++;
+        
+    } while (result->NextRow());
+    
+    LOG_INFO("server.loading", "[OllamaChat] Loaded {} sentiment records from database", count);
+}
+
+void SaveBotPlayerSentimentsToDB()
+{
+    if (!g_EnableSentimentTracking)
+        return;
+
+    std::lock_guard<std::mutex> lock(g_SentimentMutex);
+    
+    if (g_BotPlayerSentiments.empty())
+        return;
+    
+    // Use REPLACE INTO to update existing records or insert new ones
+    for (const auto& [botGuid, playerMap] : g_BotPlayerSentiments)
+    {
+        for (const auto& [playerGuid, sentimentValue] : playerMap)
+        {
+            CharacterDatabase.Execute(SafeFormat(
+                "REPLACE INTO mod_ollama_bot_player_sentiments (bot_guid, player_guid, sentiment_value) "
+                "VALUES ({}, {}, {:.3f})",
+                botGuid, playerGuid, sentimentValue));
+        }
+    }
+    
+    if (g_DebugEnabled)
+    {
+        LOG_INFO("server.loading", "[OllamaChat] Saved sentiment data to database");
+    }
+}
+
+void InitializeSentimentTracking()
+{
+    if (!g_EnableSentimentTracking)
+    {
+        LOG_INFO("server.loading", "[OllamaChat] Sentiment tracking is disabled");
+        return;
+    }
+    
+    LOG_INFO("server.loading", "[OllamaChat] Initializing sentiment tracking system...");
+    
+    // Load existing sentiment data from database
+    LoadBotPlayerSentimentsFromDB();
+    
+    // Initialize the last save time
+    g_LastSentimentSaveTime = time(nullptr);
+    
+    LOG_INFO("server.loading", "[OllamaChat] Sentiment tracking system initialized");
+}

--- a/src/mod-ollama-chat_sentiment.h
+++ b/src/mod-ollama-chat_sentiment.h
@@ -1,0 +1,66 @@
+#ifndef MOD_OLLAMA_CHAT_SENTIMENT_H
+#define MOD_OLLAMA_CHAT_SENTIMENT_H
+
+#include <string>
+#include <cstdint>
+#include "Player.h"
+
+// --------------------------------------------
+// Sentiment Tracking Functions
+// --------------------------------------------
+
+/**
+ * Get the current sentiment value between a bot and player
+ * @param botGuid GUID of the bot
+ * @param playerGuid GUID of the player
+ * @return Sentiment value (0.0-1.0), or default value if not found
+ */
+float GetBotPlayerSentiment(uint64_t botGuid, uint64_t playerGuid);
+
+/**
+ * Set the sentiment value between a bot and player
+ * @param botGuid GUID of the bot
+ * @param playerGuid GUID of the player
+ * @param sentimentValue New sentiment value (0.0-1.0)
+ */
+void SetBotPlayerSentiment(uint64_t botGuid, uint64_t playerGuid, float sentimentValue);
+
+/**
+ * Analyze the sentiment of a message using LLM
+ * @param message The message to analyze
+ * @return Sentiment adjustment (-1.0 to 1.0)
+ */
+float AnalyzeMessageSentiment(const std::string& message);
+
+/**
+ * Update sentiment based on a player's message to a bot
+ * @param bot The bot receiving the message
+ * @param player The player sending the message
+ * @param message The message content
+ */
+void UpdateBotPlayerSentiment(Player* bot, Player* player, const std::string& message);
+
+/**
+ * Get sentiment prompt addition for including in bot responses
+ * @param bot The bot
+ * @param player The player they're responding to
+ * @return Formatted sentiment prompt addition
+ */
+std::string GetSentimentPromptAddition(Player* bot, Player* player);
+
+/**
+ * Load all sentiment data from database into memory
+ */
+void LoadBotPlayerSentimentsFromDB();
+
+/**
+ * Save all sentiment data from memory to database
+ */
+void SaveBotPlayerSentimentsToDB();
+
+/**
+ * Initialize the sentiment tracking system
+ */
+void InitializeSentimentTracking();
+
+#endif // MOD_OLLAMA_CHAT_SENTIMENT_H


### PR DESCRIPTION
# Bot-Player Sentiment Tracking System

## Overview
Implements Issue #16 - A comprehensive sentiment tracking system that allows bots to develop persistent relationships with players based on their interactions over time.

## What This PR Does
- ✅ **Adds sentiment tracking between bots and players** - Bots remember how players treat them
- ✅ **LLM-powered sentiment analysis** - Automatically analyzes message sentiment (POSITIVE/NEGATIVE/NEUTRAL)  
- ✅ **Dynamic bot behavior** - Bots become friendlier to nice players, colder to rude players
- ✅ **Persistent storage** - Sentiment data survives server restarts via database
- ✅ **Admin management tools** - Complete command interface for viewing/managing sentiment
- ✅ **Configurable system** - All aspects tunable via configuration file

## Key Features

### Sentiment Analysis
- Each player message is analyzed by the LLM for emotional tone
- Sentiment values range from 0.0 (hostile) to 1.0 (friendly), default 0.5 (neutral)
- Adjustments are configurable (default ±0.1 per positive/negative message)

### Persistent Memory
- New database table: `mod_ollama_bot_player_sentiments`
- In-memory caching for performance with periodic database saves
- Thread-safe operations with proper mutex protection

### Dynamic Bot Behavior
- Sentiment automatically included in all bot prompts
- Bots receive context like: "Your sentiment with PlayerX is 0.8 (friendly)"
- Results in warmer/colder responses based on relationship history

### Admin Tools
New `.ollama sentiment` commands:
- `view [bot] [player]` - Display sentiment data
- `set <bot> <player> <value>` - Manually set sentiment  
- `reset [bot] [player]` - Reset sentiment to default

## Files Changed

### New Files
- `src/mod-ollama-chat_sentiment.h` - Sentiment system header
- `src/mod-ollama-chat_sentiment.cpp` - Core sentiment implementation
- `data/sql/characters/base/2025_07_25_sentiment_tracking.sql` - Database schema

### Modified Files
- `src/mod-ollama-chat_config.h/.cpp` - Added sentiment configuration variables
- `src/mod-ollama-chat_handler.cpp` - Integrated sentiment into chat processing
- `src/mod-ollama-chat_events.cpp` - Added sentiment to event system
- `src/mod-ollama-chat_command.h/.cpp` - Added sentiment admin commands
- `src/mod-ollama-chat_random.cpp` - Added periodic sentiment saving

## Configuration

```ini
# Enable sentiment tracking (default: 1)
OllamaChat.EnableSentimentTracking = 1

# Default sentiment for new relationships (default: 0.5)  
OllamaChat.SentimentDefaultValue = 0.5

# Sentiment adjustment per message (default: 0.1)
OllamaChat.SentimentAdjustmentStrength = 0.1

# Save interval in minutes (default: 10)
OllamaChat.SentimentSaveInterval = 10

# Sentiment analysis prompt template
OllamaChat.SentimentAnalysisPrompt = "Analyze the sentiment of this message: \"{message}\". Respond only with: POSITIVE, NEGATIVE, or NEUTRAL."

# Sentiment context template for bot prompts
OllamaChat.SentimentPromptTemplate = "Your relationship sentiment with {player_name} is {sentiment_value} (0.0=hostile, 0.5=neutral, 1.0=friendly). Use this to guide your tone and response."
```

## Database Migration

Run the included SQL file or let the server run it for you on boot to create the sentiment table:
```sql
-- Creates mod_ollama_bot_player_sentiments table
-- See: data/sql/characters/base/2025_07_25_sentiment_tracking.sql
```

## Example Usage

### Scenario: Player Interaction Evolution

1. **First meeting**: Alice says "Hello BotTank!"
   - Sentiment starts at 0.5 (neutral) 
   - Message analyzed as POSITIVE → sentiment becomes 0.6
   - Bot responds neutrally but positively

2. **Building relationship**: Alice says "You're an amazing tank!"
   - Sentiment 0.6 → 0.7 (POSITIVE message)
   - Bot responds more warmly: "Thanks Alice, always happy to help!"

3. **Conflict**: Alice says "You suck at tanking!"
   - Sentiment 0.7 → 0.6 (NEGATIVE message) 
   - Bot responds cooler: "I'm doing my best..."

4. **Long-term**: After many positive interactions
   - Sentiment reaches 0.9+ 
   - Bot greets Alice enthusiastically and prioritizes helping her

### Admin Management
```
.ollama sentiment view Alice          # See all sentiment involving Alice
.ollama sentiment view BotTank        # See all sentiment for BotTank  
.ollama sentiment set BotTank Alice 0.8  # Manually set relationship
.ollama sentiment reset               # Reset all sentiment data
```
---

**Closes #16**
