### PR TITLE
fix: ignore addon chatter

### DIFF
--- a/src/mod-ollama-chat_handler.cpp
+++ b/src/mod-ollama-chat_handler.cpp
@@ -1,4 +1,5 @@
 #include "Log.h"
+#include "Language.h"
 #include "Player.h"
 #include "Chat.h"
 #include "Channel.h"
@@ -599,7 +600,7 @@ static std::string GenerateBotGameStateSnapshot(Player* bot)
 }
 
 
-void PlayerBotChatHandler::ProcessChat(Player* player, uint32_t /*type*/, uint32_t /*lang*/, std::string& msg, ChatChannelSourceLocal sourceLocal, Channel* channel, Player* receiver)
+void PlayerBotChatHandler::ProcessChat(Player* player, uint32_t /*type*/, uint32_t lang, std::string& msg, ChatChannelSourceLocal sourceLocal, Channel* channel, Player* receiver)
 {
     if (player == nullptr) {
         LOG_ERROR("server.loading", "[Ollama Chat] ProcessChat: player is null");
@@ -608,6 +609,7 @@ void PlayerBotChatHandler::ProcessChat(Player* player, uint32_t /*type*/, uint32
     if (msg.empty()) {
         return;
     }
+    if (lang == LANG_ADDON) return;
     std::string chanName = (channel != nullptr) ? channel->GetName() : "Unknown";
     uint32_t channelId = (channel != nullptr) ? channel->GetChannelId() : 0;
     std::string receiverName = (receiver != nullptr) ? receiver->GetName() : "None";


### PR DESCRIPTION
Fixed addon chatter not being ignored. Otherwise, the bot responds to non-visible addon chatter from players. For example (with debug enabled):

```
[Ollama Chat] Player Roldan sent msg: 'SpecializedAbsorbs_Scaling       ^1^S0x0000000000002192^SPRIEST^T^N1^N9^N2^N1^N3^N0.807^N4^N0^t^^' | Source: 2 | Channel Name: Unknown | Channel ID: 0 | Receiver: None
[Ollama Chat] Bot Nicole (distance: 0) is set to respond.
[Ollama Chat] Using existing personality 'default' for bot Nicole
[Ollama Chat] Player Roldan sent msg: 'Absorbs_Scaling  ^1^S0x0000000000002192^SPRIEST^T^N1^N9^N2^N1^N3^N0.807^N4^N0^t^^' | Source: 2 | Channel Name: Unknown | Channel ID: 0 | Receiver: None
[Ollama Chat] Bot Nicole (distance: 0) is set to respond.
[Ollama Chat] Using existing personality 'default' for bot Nicole
[Ollama Chat] HTTP request successful, response length: 1985
[Ollama Chat] Parsed bot response: Uh, what's the point of that? You're just messing with me.
[Ollama Chat] HTTP Request - Protocol: http, Host: host.docker.internal, Port: 11434, Path: /api/generate
[Ollama Chat] Using standard HTTP client
[Ollama Chat] Bot Nicole (distance: 0) responded: Uh, what's the point of that? You're just messing with me.
AHBot [5146]: Begin Performing Update Cycle
WaypointMovementGenerator::LoadPath: creature Defias Thug (GUID Full: 0xf130000026003fb7 Type: Creature Entry: 38  Low: 16311) doesn't have waypoint path id: 0
[Ollama Chat] HTTP request successful, response length: 2044
[Ollama Chat] Parsed bot response: Ugh, what's with all the weird hexes? Can't you just give me some decent spellcasting info?
[Ollama Chat] HTTP Request - Protocol: http, Host: host.docker.internal, Port: 11434, Path: /api/generate
[Ollama Chat] Using standard HTTP client
[Ollama Chat] Bot Nicole (distance: 0) responded: Ugh, what's with all the weird hexes? Can't you just give me some decent spellcasting info?
```

Built and tested - Works as expected. Addon chatter no longer appearing in logs and bots no longer replying to it.