### PR TITLE
fix: blacklist word check

### DIFF
--- a/src/mod-ollama-chat_handler.cpp
+++ b/src/mod-ollama-chat_handler.cpp
@@ -620,15 +620,23 @@ void PlayerBotChatHandler::ProcessChat(Player* player, uint32_t /*type*/, uint32
                 player->GetName(), msg, (int)sourceLocal, chanName, channelId, receiverName);
     }
 
+
+    auto startsWithWord = [](const std::string& text, const std::string& word) {
+        if (text.size() < word.size()) return false;
+        if (text.compare(0, word.size(), word) != 0) return false;
+        // If exact length match or next char is whitespace/punctuation, it's a word
+        return text.size() == word.size() || !std::isalnum((unsigned char)text[word.size()]);
+    };
+
     std::string trimmedMsg = rtrim(msg);
     for (const std::string& blacklist : g_BlacklistCommands)
     {
-        if (trimmedMsg.find(blacklist) == 0)
+        if (startsWithWord(trimmedMsg, blacklist))
         {
-            if(g_DebugEnabled)
-            {
-                LOG_INFO("server.loading", "[Ollama Chat] Message starts with '{}' (blacklisted). Skipping bot responses.", blacklist);
-            }
+            if (g_DebugEnabled)
+                LOG_INFO("server.loading",
+                         "[Ollama Chat] Message starts with '{}' (blacklisted). Skipping bot responses.",
+                         blacklist);
             return;
         }
     }


### PR DESCRIPTION
The current blacklist check is incorrect, resulting in valid messages being filtered:

```
[Ollama Chat] Player Roldan sent msg: 'someone should talk to me please' | Source: 17 | Channel Name: General - Elwynn Forest | Channel ID: 1 | Receiver: None
[Ollama Chat] Message starts with 's' (blacklisted). Skipping bot responses.
```

In the blacklist:

```
OllamaChat.BlacklistCommands = autogear,talents,reset botAI,summon,release,revive,leave,attack,follow,flee,stay,runaway,grind,disperse,give leader,spells,cast ,quests,accept,drop,talk,reset,ss ,trainer,rti,rtsc,do ,ll ,e ,ue ,nc ,open,destroy,s ,b ,bank,gb ,u ,co ,ELVUI_VERSIONCHK,Asked,DPSMate_,LibGroupTalents,BLT,oRA3,Skada,HealBot,hbComms,questie,pfQuest,DBMv4-Ver,BWVQ3,add,remove,reset ai,report,state,help,log,stats,tank,offtank,healer,cc ,damage,boost,passive,defensive,aggressive,stay,guard,free,follow,assist,pet,stance,formation,rpg,emote,cheer,applaud,drink,eat,dance,attackers,reset instances,home,zone,who ,pos ,tele,grind,loot,quest,trainer,travel,teleport,homebind,unfollow,invite,uninvite,join,leave,leader,ready,release,save,update,reset talents,gear,trade,mail,ah ,ahscan,ahbid,ahbuy,ahsell,ahcancel,bag,repair,vendor,train,spells,reset spells,learn,unlearn,cast,uncast,use ,move,go ,look,stop,turn,face,wait,party,followleader,stayleader,moveleader,info,distance,debug,reset path,reset state,reset all,reset dungeon,reset raid,zone info,LHC40,RECOUNT,GTFO_v,Altoholic,DS_,DataStore
```

It should be filtering by `s ` with a space. However, as you can see from above, it is not doing this. This PR aims to fix this.

Post fix:

```
[Ollama Chat] Player Roldan sent msg: 'someone should talk to me please' | Source: 17 | Channel Name: General - Elwynn Forest | Channel ID: 1 | Receiver: None
[Ollama Chat] Processing channel message in 'General - Elwynn Forest' (ID: 1)
[Ollama Chat] Found 54 bots in channel instance 'General - Elwynn Forest'
[Ollama Chat] Bot Iridessa (distance: 1282.1093) is set to respond.
[Ollama Chat] HTTP Request - Protocol: http, Host: host.docker.internal, Port: 11434, Path: /api/generate
[Ollama Chat] Using standard HTTP client
[Ollama Chat] HTTP request successful, response length: 1808
[Ollama Chat] Parsed bot response: Hey Roldan, what's up? Don't be talkin' about yourself so much.
[Ollama Chat] Bot Iridessa found channel 'General - Elwynn Forest' (ID: 1), checking membership...
[Ollama Chat] Bot Iridessa is confirmed in channel 'General - Elwynn Forest', sending message...
[Ollama Chat] Bot Iridessa responded in channel General - Elwynn Forest: Hey Roldan, what's up? Don't be talkin' about yourself so much.
[Ollama Chat] Bot Iridessa (distance: 1242.1313) responded: Hey Roldan, what's up? Don't be talkin' about yourself so much.
...
[Ollama Chat] Player Roldan sent msg: 's omeone should not talk to me' | Source: 17 | Channel Name: General - Elwynn Forest | Channel ID: 1 | Receiver: None
[Ollama Chat] Message starts with 's' (blacklisted). Skipping bot responses.
```


A couple extra tests:

```
[Ollama Chat] Player Roldan sent msg: 's omeone should not talk to me' | Source: 17 | Channel Name: General - Elwynn Forest | Channel ID: 1 | Receiver: None
[Ollama Chat] Message starts with 's' (blacklisted). Skipping bot responses.
[Ollama Chat] Player Roldan sent msg: 'passive defense' | Source: 17 | Channel Name: General - Elwynn Forest | Channel ID: 1 | Receiver: None
[Ollama Chat] Message starts with 'passive' (blacklisted). Skipping bot responses.
...
[Ollama Chat] Player Roldan sent msg: 'hello passive' | Source: 17 | Channel Name: General - Elwynn Forest | Channel ID: 1 | Receiver: None
[Ollama Chat] Processing channel message in 'General - Elwynn Forest' (ID: 1)
[Ollama Chat] Found 63 bots in channel instance 'General - Elwynn Forest'
[Ollama Chat] Bot Wilani (distance: 1538.0564) is set to respond.
[Ollama Chat] HTTP Request - Protocol: http, Host: host.docker.internal, Port: 11434, Path: /api/generate
[Ollama Chat] Using standard HTTP client
```