### PR TITLE
Add configurable delays to responses

### DIFF
--- a/conf/mod_ollama_chat.conf.dist
+++ b/conf/mod_ollama_chat.conf.dist
@@ -791,3 +791,31 @@ OllamaChat.RAGSimilarityThreshold = 0.3
 #     Description: Template for including RAG information in bot prompts.
 #     Placeholders (named): {rag_info}
 OllamaChat.RAGPromptTemplate = "RELEVANT INFORMATION:\n{rag_info}\nUse this information to provide accurate and detailed responses when applicable."
+
+# --------------------------------------------
+# RESPONSE TIMING SIMULATION
+# --------------------------------------------
+
+# OllamaChat.EnableResponseDelay
+#     Description: Enable or disable response delay to simulate thinking time.
+#                  When enabled (1), the bot will wait a random time between MinResponseTimeMs and MaxResponseTimeMs before responding.
+#                  When disabled (0), the bot will respond as soon as response is ready.
+#     Default:     0 (false)
+OllamaChat.EnableResponseDelay = 0
+
+# OllamaChat.MinResponseTimeMs
+#     Description: Minimum response time in milliseconds to simulate thinking/typing time.
+#     Default:     1000
+OllamaChat.MinResponseTimeMs = 1000
+
+# OllamaChat.MaxResponseTimeMs
+#     Description: Maximum response time in milliseconds to simulate thinking/typing time.
+#     Default:     15000
+OllamaChat.MaxResponseTimeMs = 15000
+
+# OllamaChat.ResponseWeightedByMessageLength
+#     Description: Weight the response delay based on the length of the player's message.
+#                  Value between 0.0 (no weighting) and 1.0 (fully weighted).
+#                  Higher values will increase delay for longer messages.
+#     Default:     0.5
+OllamaChat.ResponseWeightedByMessageLength = 0.5

--- a/src/mod-ollama-chat_config.cpp
+++ b/src/mod-ollama-chat_config.cpp
@@ -257,6 +257,14 @@ uint32_t g_EventCooldownTime = 10;
 // --------------------------------------------
 bool g_RestrictBotsToPartyMembers = false;
 
+// --------------------------------------------
+// Timing
+// --------------------------------------------
+// settings to control how fast the bot can respond
+bool     g_EnableResponseDelay = false;         //New feature so default to off
+uint32_t g_MinResponseTimeMs = 1000;            // minimum response time in milliseconds
+uint32_t g_MaxResponseTimeMs = 15000;            // maximum response time in milliseconds
+float    g_ResponseWeightedByMessageLength = 0.5f; // 0.0 = no weighting, completely random, 1.0 = fully weighted by message length, not random
 
 static std::vector<std::string> SplitString(const std::string& str, char delim)
 {
@@ -560,12 +568,20 @@ void LoadOllamaChatConfig()
     // Party restriction settings
     g_RestrictBotsToPartyMembers = sConfigMgr->GetOption<bool>("OllamaChat.RestrictBotsToPartyMembers", false);
 
+    /*
+    Time settings to control bot response speed
+    */
+    g_EnableResponseDelay = sConfigMgr->GetOption<bool>("OllamaChat.EnableResponseDelay", false);
+    g_MinResponseTimeMs = sConfigMgr->GetOption<uint32_t>("OllamaChat.MinResponseTimeMs", 1000);
+    g_MaxResponseTimeMs = sConfigMgr->GetOption<uint32_t>("OllamaChat.MaxResponseTimeMs", 15000);
+    g_ResponseWeightedByMessageLength = sConfigMgr->GetOption<float>("OllamaChat.ResponseWeightedByMessageLength", 0.5f);
+
     LOG_INFO("server.loading",
-             "[Ollama Chat] Config loaded: Enabled = {}, SayDistance = {}, YellDistance = {}, "
+             "[Ollama Chat] Config loaded: Enabled = {}, SayDistance = {}, YellDistance = {}, EnableResponseDelay = {}, "
              "PlayerReplyChance = {}%, BotReplyChance = {}%, MaxBotsToPick = {}, "
              "Url = {}, Model = {}, MaxConcurrentQueries = {}, EnableRandomChatter = {}, MinRandInt = {}, MaxRandInt = {}, RandomChatterRealPlayerDistance = {}, "
              "RandomChatterBotCommentChance = {}. MaxConcurrentQueries = {}. Extra blacklist commands: {}",
-             g_Enable, g_SayDistance, g_YellDistance,
+             g_Enable, g_SayDistance, g_YellDistance, g_EnableResponseDelay,
              g_PlayerReplyChance, g_BotReplyChance, g_MaxBotsToPick,
              g_OllamaUrl, g_OllamaModel, g_MaxConcurrentQueries,
              g_EnableRandomChatter, g_MinRandomInterval, g_MaxRandomInterval, g_RandomChatterRealPlayerDistance,

--- a/src/mod-ollama-chat_config.h
+++ b/src/mod-ollama-chat_config.h
@@ -258,6 +258,15 @@ extern uint32_t g_EventCooldownTime;
 extern bool g_RestrictBotsToPartyMembers;
 
 // --------------------------------------------
+// Timing
+// --------------------------------------------
+// settings to control how fast the bot can respond
+extern bool     g_EnableResponseDelay;          // Enable/disable response delay feature
+extern uint32_t g_MinResponseTimeMs;            // minimum response time in milliseconds
+extern uint32_t g_MaxResponseTimeMs;            // maximum response time in milliseconds
+extern float    g_ResponseWeightedByMessageLength;
+
+// --------------------------------------------
 // Loader Functions
 // --------------------------------------------
 void LoadOllamaChatConfig();


### PR DESCRIPTION
Often bots will respond more quickly than possible and might have a whole conversation faster than you can read it.

This adds an option to enable sleeping of api responses before they are returned, effectively simulating think/typing time. A few configurable options were added to control this functionality.
- Enable/Disable
``OllamaChat.EnableResponseDelay = 0``
- Min Response time
``OllamaChat.MinResponseTimeMs = 1000``
- Max Response time
``OllamaChat.MaxResponseTimeMs = 15000``
- Random, vs content delay weight, 0 completely random within window, 1 completely response length based
``OllamaChat.ResponseWeightedByMessageLength = 0.5``