### PR TITLE
Add BotToBotMentionReplyChance to fix bot-to-bot reply deallock

### DIFF
--- a/conf/mod_ollama_chat.conf.dist
+++ b/conf/mod_ollama_chat.conf.dist
@@ -181,6 +181,13 @@ OllamaChat.PlayerReplyChance.Guild = 70
 #     Default:     5
 OllamaChat.BotReplyChance.Guild = 5
 
+# OllamaChat.BotToBotMentionReplyChance
+#     Description: The percent chance (0-100) that a bot replies when another bot's LLM-generated message
+#                  incidentally mentions its name. Keep this low to dampen bot-to-bot reply chains across
+#                  all channels (Say, Party, Raid, Guild, General, etc.).
+#     Default:     50
+OllamaChat.BotToBotMentionReplyChance = 50
+
 # OllamaChat.EnableWhisperReplies
 #     Description: Enable or disable bot responses to whisper messages.
 #                  When set to 0 (false), bots will not reply to any whispers.

--- a/src/mod-ollama-chat_config.cpp
+++ b/src/mod-ollama-chat_config.cpp
@@ -29,6 +29,7 @@ uint32_t   g_PlayerReplyChance_Party   = 90;
 uint32_t   g_BotReplyChance_Party      = 10;
 uint32_t   g_PlayerReplyChance_Guild   = 70;
 uint32_t   g_BotReplyChance_Guild      = 5;
+uint32_t   g_BotToBotMentionReplyChance   = 50;
 
 uint32_t   g_MaxBotsToPick     = 2;
 uint32_t   g_RandomChatterBotCommentChance   = 5;
@@ -382,7 +383,8 @@ void LoadOllamaChatConfig()
     g_BotReplyChance_Party            = sConfigMgr->GetOption<uint32_t>("OllamaChat.BotReplyChance.Party", 10);
     g_PlayerReplyChance_Guild         = sConfigMgr->GetOption<uint32_t>("OllamaChat.PlayerReplyChance.Guild", 70);
     g_BotReplyChance_Guild            = sConfigMgr->GetOption<uint32_t>("OllamaChat.BotReplyChance.Guild", 5);
-    
+    g_BotToBotMentionReplyChance      = sConfigMgr->GetOption<uint32_t>("OllamaChat.BotToBotMentionReplyChance", 50);
+
     g_MaxBotsToPick                   = sConfigMgr->GetOption<uint32_t>("OllamaChat.MaxBotsToPick", 2);
     g_OllamaUrl                       = sConfigMgr->GetOption<std::string>("OllamaChat.Url", "http://localhost:11434/api/generate");
     g_OllamaModel                     = sConfigMgr->GetOption<std::string>("OllamaChat.Model", "llama3.2:1b");

--- a/src/mod-ollama-chat_config.h
+++ b/src/mod-ollama-chat_config.h
@@ -30,6 +30,7 @@ extern uint32_t   g_PlayerReplyChance_Party;
 extern uint32_t   g_BotReplyChance_Party;
 extern uint32_t   g_PlayerReplyChance_Guild;
 extern uint32_t   g_BotReplyChance_Guild;
+extern uint32_t   g_BotToBotMentionReplyChance;
 
 extern uint32_t   g_MaxBotsToPick;
 extern uint32_t   g_RandomChatterBotCommentChance;

--- a/src/mod-ollama-chat_handler.cpp
+++ b/src/mod-ollama-chat_handler.cpp
@@ -1316,11 +1316,21 @@ void PlayerBotChatHandler::ProcessChat(Player* player, uint32_t /*type*/, uint32
             Player* chosen = mentionedBots.front().second;
             if (!(g_DisableRepliesInCombat && chosen->IsInCombat()))
             {
-                finalCandidates.push_back(chosen);
-                if(g_DebugEnabled)
+                bool selected = true;
+                if (senderIsBot)
                 {
-                    LOG_INFO("server.loading", "[Ollama Chat] Bot {} selected (mentioned first at position {})", 
-                            chosen->GetName(), mentionedBots.front().first);
+                    uint32_t mentionRoll = urand(0, 99);
+                    selected = (mentionRoll < g_BotToBotMentionReplyChance);
+                }
+
+                if (selected)
+                {
+                    finalCandidates.push_back(chosen);
+                    if(g_DebugEnabled)
+                    {
+                        LOG_INFO("server.loading", "[Ollama Chat] Bot {} selected (mentioned first at position {})",
+                                chosen->GetName(), mentionedBots.front().first);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When a bot's name is mentioned in a message, it was previously selected with 100% probability, bypassing the normal reply chance roll. This caused infinite reply loops between two bots that kept mentioning each other in LLM-generated responses.

Adds OllamaChat.BotToBotMentionReplyChance (default 50%) so that even explicitly mentioned bots are subject to a probability check when the sender is also a bot.